### PR TITLE
Restore git tests

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-@typescript:registry=https://devdiv.pkgs.visualstudio.com/_packaging/TypeScript-Tools/npm/registry/
-always-auth=true

--- a/azure-pipelines-userTests.yml
+++ b/azure-pipelines-userTests.yml
@@ -27,16 +27,13 @@ pool:
   vmImage: 'ubuntu-latest'
 
 jobs:
-- job: 'DetectNewErrors'
+- job: 'UserTestInline'
   timeoutInMinutes: 360
   steps:
   - task: NodeTool@0
     inputs:
       versionSpec: '12.x'
     displayName: 'Install Node.js'
-  - task: npmAuthenticate@0
-    inputs:
-      workingFile: './.npmrc'
   - script: |
       npm ci
       npm run build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,16 +5,13 @@ pool:
   vmImage: 'ubuntu-latest'
 
 jobs:
-- job: 'DetectNewErrors'
+- job: 'BuildAndTest'
   timeoutInMinutes: 360
   steps:
   - task: NodeTool@0
     inputs:
       versionSpec: '16.x'
     displayName: 'Install Node.js'
-  - task: npmAuthenticate@0
-    inputs:
-      workingFile: './.npmrc'
   - script: |
       npm ci
       npm run build

--- a/getErrors.test.ts
+++ b/getErrors.test.ts
@@ -7,6 +7,7 @@ describe("getErrors", () => {
             "./test/simpleProject",
             // TODO: Depends on downloading and building 44585 in main.test.ts
             path.resolve("./typescript-test-fake-error/built/local/tsc.js"),
+            'user',
             /*skipLibCheck*/ true,
         )
         expect(errors.hasConfigFailure).toBeFalsy()
@@ -24,6 +25,7 @@ describe("getErrors", () => {
             "./test/scriptProject",
             // TODO: Depends on downloading and building 44585 in main.test.ts
             path.resolve("./typescript-test-fake-error/built/local/tsc.js"),
+            'user',
             /*skipLibCheck*/ true,
         )
         expect(errors.hasConfigFailure).toBeFalsy()
@@ -41,6 +43,7 @@ describe("getErrors", () => {
             "./test/scriptPrettier",
             // TODO: Depends on downloading and building 44585 in main.test.ts
             path.resolve("./typescript-test-fake-error/built/local/tsc.js"),
+            'user',
             /*skipLibCheck*/ true,
         )
         expect(errors.hasConfigFailure).toBeFalsy()

--- a/getErrors.ts
+++ b/getErrors.ts
@@ -1,3 +1,4 @@
+import ghUrl = require("@typescript/github-url");
 import packageUtils = require("./packageUtils");
 import projectGraph = require("./projectGraph");
 import cp = require("child_process");
@@ -68,7 +69,10 @@ export interface RepoErrors {
  * @param tscPath The path to tsc.js.
  * @param skipLibCheck True pass --skipLibCheck when building non-composite projects.  (Defaults to true)
  */
-export async function buildAndGetErrors(repoDir: string, tscPath: string, skipLibCheck: boolean = true): Promise<RepoErrors> {
+export async function buildAndGetErrors(repoDir: string, tscPath: string, testType: 'git' | 'user', skipLibCheck: boolean = true): Promise<RepoErrors> {
+    // TODO: Either add a new testType (passed in to here) or a new projectType (detected by projectGraph.getProjectsToBuild(repoDir)
+    // *probably* it makes more sense to add a testType, especially since the 'git' test type isn't needed here. It's from the fuzzer.
+    // (if we wanted to keep 'git', the 3 things aren't in one category)
     const simpleBuildArgs = `--skipLibCheck ${skipLibCheck} --incremental false --pretty false -p`;
     const compositeBuildArgs = `-b -f -v`; // Build mode doesn't support --skipLibCheck or --pretty
 
@@ -89,7 +93,7 @@ export async function buildAndGetErrors(repoDir: string, tscPath: string, skipLi
         if (isEmpty) continue;
 
         const projectDir = path.dirname(projectPath);
-        const projectUrl = projectPath; // Use project path for user tests as they don't contain a git project.
+        const projectUrl = testType === "user" ? projectPath : await ghUrl.getGithubUrl(projectPath); // Use project path for user tests as they don't contain a git project.
 
         let localErrors: LocalError[] = [];
         let currProjectUrl = projectUrl;
@@ -98,7 +102,7 @@ export async function buildAndGetErrors(repoDir: string, tscPath: string, skipLi
         for (const line of lines) {
             const projectMatch = isComposite && line.match(beginProjectRegex);
             if (projectMatch) {
-                currProjectUrl = path.resolve(projectDir, projectMatch[1]);
+                currProjectUrl = testType === "user" ? path.resolve(projectDir, projectMatch[1]) : await ghUrl.getGithubUrl(path.resolve(projectDir, projectMatch[1]));
                 continue;
             }
             const localError = getLocalErrorFromLine(line, currProjectUrl);
@@ -110,7 +114,7 @@ export async function buildAndGetErrors(repoDir: string, tscPath: string, skipLi
         const errors = localErrors.filter(le => !le.path).map(le => ({ projectUrl: le.projectUrl, code: le.code, text: le.text } as Error));
 
         const fileLocalErrors = localErrors.filter(le => le.path).map(le => ({ ...le, path: path.resolve(projectDir, le.path!) }));
-        const fileUrls = fileLocalErrors.map(x => `${x.path}(${x.lineNumber},${x.columnNumber})`);
+        const fileUrls = testType === "user" ? fileLocalErrors.map(x => `${x.path}(${x.lineNumber},${x.columnNumber})`) : await ghUrl.getGithubUrls(fileLocalErrors);
         for (let i = 0; i < fileLocalErrors.length; i++) {
             const localError = fileLocalErrors[i];
             errors.push({

--- a/getErrors.ts
+++ b/getErrors.ts
@@ -1,4 +1,4 @@
-import ghUrl = require("@typescript/github-url");
+import ghUrl = require("./github-url/index");
 import packageUtils = require("./packageUtils");
 import projectGraph = require("./projectGraph");
 import cp = require("child_process");

--- a/gitErrors.ts
+++ b/gitErrors.ts
@@ -1,0 +1,21 @@
+import path = require("path");
+import { mainAsync, reportError } from "./main";
+
+const { argv } = process;
+
+if (argv.length !== 6) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <post_result> <repo_count> <old_tsc_version> <new_tsc_version>`);
+    process.exit(-1);
+}
+
+mainAsync({
+    testType: "git",
+    postResult: argv[2].toLowerCase() === "true", // Only accept true.
+    tmpfs: true,
+    repoCount: +argv[3],
+    oldTscVersion: argv[4],
+    newTscVersion: argv[5],
+}).catch(err => {
+    reportError(err, "Unhandled exception");
+    process.exit(1);
+});

--- a/gitUtils.ts
+++ b/gitUtils.ts
@@ -1,6 +1,7 @@
 import octokit = require("@octokit/rest");
 import utils = require("./packageUtils");
 import git = require("simple-git/promise");
+import fs = require("fs");
 import path = require("path");
 import cp = require("child_process");
 
@@ -16,6 +17,51 @@ const repoProperties = {
     owner: "microsoft",
     repo: "typescript",
 };
+
+export async function getPopularTypeScriptRepos(count = 100, cachePath?: string): Promise<readonly Repo[]> {
+    const cacheEncoding = { encoding: "utf-8" } as const;
+
+    if (cachePath && await utils.exists(cachePath)) {
+        const contents = await fs.promises.readFile(cachePath, cacheEncoding);
+        const cache: Repo[] = JSON.parse(contents);
+        if (cache.length >= count) {
+            return cache.slice(0, count);
+        }
+    }
+
+    const kit = new octokit.Octokit();
+    const perPage = Math.min(100, count);
+
+    let repos: Repo[] = [];
+    for (let page = 1; repos.length < count; page++) {
+        const response = await kit.search.repos({
+            q: "language:TypeScript+stars:>100 archived:no",
+            sort: "stars",
+            order: "desc",
+            per_page: perPage,
+            page,
+        });
+
+        if (response.status !== 200) throw response;
+
+        for (const repo of response.data.items) {
+            if (repo.full_name !== "microsoft/TypeScript" && repo.full_name !== "DefinitelyTyped/DefinitelyTyped") {
+                repos.push({ url: repo.html_url, name: repo.name, owner: repo.owner.login });
+            }
+            if (repos.length >= count) {
+                break;
+            }
+        }
+
+        if (!response.headers.link || !response.headers.link.includes('rel="next"')) break;
+    }
+
+    if (cachePath) {
+        await fs.promises.writeFile(cachePath, JSON.stringify(repos), cacheEncoding);
+    }
+
+    return repos;
+}
 
 export async function cloneRepoIfNecessary(parentDir: string, repo: Repo): Promise<void> {
     if (!repo.url) {
@@ -34,14 +80,48 @@ export async function cloneRepoIfNecessary(parentDir: string, repo: Repo): Promi
     }
 }
 
-export type Result = {
+type Result = {
     body: string,
     owner: string,
     repo: string,
-    issue_number: number,
+}
+export type GitResult = Result & { kind: 'git', title: string }
+export type UserResult = Result & { kind: 'user', issue_number: number }
+
+export async function createIssue(postResult: boolean, title: string, body: string, sawNewErrors: boolean): Promise<GitResult | undefined> {
+    const issue = {
+        ...repoProperties,
+        title,
+        body,
+    };
+
+    if (!postResult) {
+        console.log("Issue not posted: ");
+        console.log(JSON.stringify(issue));
+        return { kind: 'git', ...issue };
+    }
+
+    console.log("Creating a summary issue");
+
+    const kit = new octokit.Octokit({
+        auth: process.env.GITHUB_PAT,
+    });
+
+    const created = await kit.issues.create(issue);
+
+    const issueNumber = created.data.number;
+    console.log(`Created issue #${issueNumber}: ${created.data.html_url}`);
+
+    if (!sawNewErrors) {
+        await kit.issues.update({
+            ...repoProperties,
+            issue_number: issueNumber,
+            state: "closed",
+        });
+    }
 }
 
-export async function createComment(sourceIssue: number, statusComment: number, postResult: boolean, body: string): Promise<Result | undefined> {
+export async function createComment(sourceIssue: number, statusComment: number, postResult: boolean, body: string): Promise<UserResult | undefined> {
     const newComment = {
         ...repoProperties,
         issue_number: sourceIssue,
@@ -51,11 +131,11 @@ export async function createComment(sourceIssue: number, statusComment: number, 
     if (!postResult) {
         console.log("Comment not posted: ");
         console.log(JSON.stringify(newComment));
-        return newComment;
+        return { kind: 'user', ...newComment };
     }
 
     console.log("Creating a github comment");
-
+    
     const kit = new octokit.Octokit({
         auth: process.env.GITHUB_PAT,
     });

--- a/github-url/index.ts
+++ b/github-url/index.ts
@@ -1,0 +1,144 @@
+import cp = require("child_process");
+import path = require("path");
+import url = require("url");
+
+if (require.main === module) {
+    const { argv } = process;
+
+    if (argv.length !== 3 && argv.length !== 4) {
+        console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} {file_path} [{line_number}]`);
+        process.exit(-1);
+    }
+
+    let localPath = argv[2];
+    let lineNumber = argv[3]; // May be undefined
+
+    if (!lineNumber) {
+        const lineNumberMatch = localPath.match(/[:,]([0-9]+)/);
+        if (lineNumberMatch) {
+            lineNumber = lineNumberMatch[1];
+            localPath = localPath.substr(0, lineNumberMatch.index);
+        }
+    }
+
+    getGithubUrl(localPath, !!lineNumber ? +lineNumber : undefined).then(
+        url => {
+            console.log(url);
+        },
+        err => {
+            console.error(err.message);
+            process.exit(-2);
+        });
+}
+
+export interface SourceLocation {
+    path: string;
+    lineNumber?: number;
+}
+
+/**
+ * Returns a GitHub URL (or a file URL, if the file is untracked).
+ * Throws if no appropriate remote can be identified.
+ */
+export async function getGithubUrl(path: string, lineNumber?: number): Promise<string> {
+    return (await getGithubUrlWorker([{ path, lineNumber }]))[0];
+}
+
+/**
+ * Returns a GitHub URL (or a file URL, if untracked) for each location.
+ * Throws if no appropriate remote can be identified.
+ */
+export async function getGithubUrls(locations: readonly SourceLocation[]): Promise<string[]> {
+    return await getGithubUrlWorker(locations);
+}
+
+async function getGithubUrlWorker(locations: readonly SourceLocation[]): Promise<string[]> {
+    if (!locations.length) {
+        return [];
+    }
+
+    const cwd = path.dirname(locations[0].path);
+
+    // This is a clever way to quickly retrieve the current commit
+    const commit = await getExecOutput("git", ["rev-parse", "@"], cwd);
+    if (!commit) {
+        throw new Error(`Couldn't identify commit - not a repository?`);
+    }
+
+    const preferredRemote = await getPreferredRemote(cwd, commit);
+    if (!preferredRemote) {
+        throw new Error(`Commit ${commit} is not present on any remote`);
+    }
+
+    const repoUrl = (await getExecOutput("git", ["remote", "get-url", `${preferredRemote}`], cwd)).replace(/\.git$/, "");
+
+    // In practice, it's common to see many requests for (different lines in) the same file
+    const serverPathCache = new Map<string, string>(); // local to server
+
+    const urls: string[] = [];
+    for (const location of locations) {
+        const localPath = path.resolve(location.path);
+        const lineNumber = location.lineNumber;
+
+        // We would just use path math, but this will also respect git's casing
+
+        let serverPath = serverPathCache.get(localPath);
+        if (!serverPath) {
+            serverPath = await getExecOutput("git", ["ls-files", "--full-name", "--", `${localPath}`], cwd);
+            serverPathCache.set(localPath, serverPath);
+        }
+
+        // Use a file URL if the file is untracked
+        const fileUrl = serverPath
+            ? `${repoUrl}/blob/${commit}/${serverPath}`
+            : url.pathToFileURL(localPath).toString();
+
+        // Cheat and add line numbers to file URLs too - VS Code handles it
+        urls.push(lineNumber ? `${fileUrl}#L${lineNumber}` : fileUrl);
+    }
+    return urls;
+}
+
+async function getPreferredRemote(cwd: string, commit: string): Promise<string | undefined> {
+    let containingRemotes: string[] = [];
+    const refsRegex = /^refs\/remotes\/([^\/]+)/gm;
+    const refs = await getExecOutput("git", ["for-each-ref", `--format=%(refname)`, "--contains", commit, "refs/remotes"], cwd);
+    let refMatch: RegExpExecArray | null;
+    while (refMatch = refsRegex.exec(refs)) {
+        containingRemotes.push(refMatch[1]);
+    }
+
+    if (containingRemotes.length) {
+        return containingRemotes.find(r => r === "origin") || containingRemotes[0];
+    }
+
+    // Sometimes, the for-each-ref trick doesn't work (e.g. in some submodules), so we fall back on a slower method
+
+    // Sort `origin` to the front, if it's present
+    const allRemotes = (await getExecOutput("git", ["remote"], cwd)).split(/\r\n?|\n/).sort((a, b) => +(b === "origin") - +(a === "origin"));
+
+    for (const remote of allRemotes) {
+        const status = await getSpawnExitCode("git", ["fetch", "--dry-run", "--quiet", remote, commit], cwd);
+        if (status === 0) {
+            return remote;
+        }
+    }
+
+    return undefined;
+}
+
+function getExecOutput(command: string, args: readonly string[], cwd: string): Promise<string> {
+    return new Promise(resolve => {
+        cp.execFile(command, args, { cwd, encoding: "utf-8" }, (err, stdout, stderr) => {
+            resolve((err || stderr) ? "" : stdout.trim());
+        });
+    });
+}
+
+function getSpawnExitCode(command: string, args: readonly string[], cwd: string): Promise<number> {
+    return new Promise(resolve => {
+        const proc = cp.spawn(command, args, { cwd, stdio: "ignore" });
+        proc.on("close", code => resolve(code!));
+        proc.stderr
+    });
+}

--- a/installPackages.ts
+++ b/installPackages.ts
@@ -21,16 +21,27 @@ export interface InstallCommand {
  * Traverses the given directory and returns a list of commands that can be used, in order, to restore
  * the packages required for building.
  */
-export async function restorePackages(repoDir: string, types?: string[]): Promise<readonly InstallCommand[]> {
+export async function restorePackages(repoDir: string, ignoreScripts: boolean = true, recursiveSearch: boolean, lernaPackages?: readonly string[], types?: string[]): Promise<readonly InstallCommand[]> {
+    lernaPackages = lernaPackages ?? await utils.getLernaOrder(repoDir);
+
     // The existence of .yarnrc.yml indicates that this repo uses yarn 2
     const isRepoYarn2 = await utils.exists(path.join(repoDir, ".yarnrc.yml"));
 
     const commands: InstallCommand[] = [];
 
-    const globPattern = "package.json";
+    const globPattern = recursiveSearch ? "**/package.json" : "package.json";
     const packageFiles = utils.glob(repoDir, globPattern);
 
     for (const packageFile of packageFiles) {
+        let inLernaPackageDir = false;
+        for (const lernaPackage of lernaPackages) {
+            if (inLernaPackageDir = packageFile.startsWith(lernaPackage)) break;
+        }
+        if (inLernaPackageDir) {
+            // Skipping restore of lerna package
+            continue;
+        }
+
         // CONSIDER: If we're ignoring scripts, there are lerna packages, and we're not
         // using yarn workspaces, we might want to `lerna bootstrap`.  In practice,
         // this has not proven to be necessary, since this combination is uncommon.
@@ -49,7 +60,11 @@ export async function restorePackages(repoDir: string, types?: string[]): Promis
                 args = ["install"]
             }
             else {
-                args = ["install", "--silent", "--ignore-engines", "--ignore-scripts"];
+                args = ["install", "--silent", "--ignore-engines"];
+
+                if (ignoreScripts) {
+                    args.push("--ignore-scripts");
+                }
             }
         }
         else if (await utils.exists(path.join(packageRoot, "package.json"))) {
@@ -58,7 +73,11 @@ export async function restorePackages(repoDir: string, types?: string[]): Promis
             const haveLock = await utils.exists(path.join(packageRoot, "package-lock.json")) ||
                 await hasCurrentShrinkwrap(packageRoot);
 
-            args = [haveLock ? "ci" : "install", "--prefer-offline", "--no-audit", "-q", "--no-progress", "--ignore-scripts"];
+            args = [haveLock ? "ci" : "install", "--prefer-offline", "--no-audit", "-q", "--no-progress"];
+
+            if (ignoreScripts) {
+                args.push("--ignore-scripts");
+            }
         }
         else {
             continue;

--- a/main.test.ts
+++ b/main.test.ts
@@ -1,40 +1,45 @@
 /// <reference types="jest" />
-import { mainAsync, innerloop, Params, downloadTypescriptRepoAsync } from './main'
+import { mainAsync, innerloop, UserParams, downloadTypescriptRepoAsync } from './main'
 import { execSync } from "child_process"
 import { existsSync } from "fs"
-import { Result } from './gitUtils'
+import { UserResult } from './gitUtils'
 import path = require('path')
 describe("main", () => {
     jest.setTimeout(10 * 60 * 1000)
-    it("user tests run from scratch", async () => {
-        const options: Params = {
+    xit("user tests run from scratch", async () => {
+        const options: UserParams = {
             postResult: false, // for testing
             tmpfs: false,
             repoCount: 1, // also for testing
+            testType: "user",
             oldTypescriptRepoUrl: 'https://github.com/microsoft/typescript',
             oldHeadRef: 'main', // TODO: only branch names seem to work here, not all refs
             requestingUser: 'sandersn',
             sourceIssue: 44585,
             statusComment: 990374547,
         }
-        await execSync("rm -rf ./ts_downloads")
-        await execSync("rm -rf ./typescript-main")
-        await execSync("rm -rf ./typescript-44585")
         const result = await mainAsync(options)
         expect(result).toBeDefined()
-        const ur = result as Result;
+        const ur = result as UserResult;
+        expect(ur.kind).toEqual('user')
         expect(ur.owner).toEqual('microsoft')
         expect(ur.repo).toEqual('typescript')
         expect(ur.issue_number).toEqual(44585)
-        expect(ur.body.includes("The results of the user tests run you requested are in!")).toBeTruthy()
-        expect(ur.body.includes("TypeScript-Node-Starter/tsconfig.json")).toBeTruthy()
-        expect(ur.body.includes("- \`error TS2496: The 'arguments' object cannot be referenced in an arrow function in ES3 and ES5. Consider using a standard function expression.\`")).toBeTruthy()
+        expect(ur.body.startsWith(`@sandersn
+The results of the user tests run you requested are in!
+<details><summary> Here they are:</summary><p>
+<b>Comparison Report - main..refs/pull/44585/merge</b>
+
+# [TypeScript-Node-Starter](https://github.com/Microsoft/TypeScript-Node-Starter.git)
+### /mnt/ts_downloads/TypeScript-Node-Starter/tsconfig.json
+- \`error TS2496: The 'arguments' object cannot be referenced in an arrow function in ES3 and ES5. Consider using a standard function expression.\``)).toBeTruthy()
     })
     it("build-only correctly caches", async () => {
-        const options: Params = {
+        const options: UserParams = {
             postResult: false, // for testing
             tmpfs: false,
             repoCount: 1, // also for testing
+            testType: "user",
             oldTypescriptRepoUrl: 'https://github.com/microsoft/typescript',
             oldHeadRef: 'main', // TODO: only branch names seem to work here, not all refs
             requestingUser: 'sandersn',

--- a/main.ts
+++ b/main.ts
@@ -1,13 +1,14 @@
 import ge = require("./getErrors");
 import pu = require("./packageUtils");
 import git = require("./gitUtils");
+import type { GitResult, UserResult } from './gitUtils'
 import ip = require("./installPackages");
 import ur = require("./userRepos");
 import cp = require("child_process");
 import fs = require("fs");
 import path = require("path");
 
-export interface Params {
+interface Params {
     /** True to post the result to Github, false to print to console.  */
     postResult: boolean;
     /** Store test repos on a tmpfs */
@@ -18,6 +19,14 @@ export interface Params {
      * User repos start at the top of the list; default is all of them.
      */
     repoCount?: number | undefined;
+}
+export interface GitParams extends Params {
+    testType: 'git';
+    oldTscVersion: string;
+    newTscVersion: string;
+}
+export interface UserParams extends Params {
+    testType: 'user';
     oldTypescriptRepoUrl: string;
     oldHeadRef: string;
     sourceIssue: number;
@@ -32,7 +41,8 @@ const skipRepos = [
 const processCwd = process.cwd();
 const processPid = process.pid;
 const executionTimeout = 10 * 60 * 1000;
-export async function innerloop(params: Params, downloadDir: string, userTestDir: string, repo: git.Repo, oldTscPath: string, newTscPath: string, outputs: string[]) {
+export async function innerloop(params: GitParams | UserParams, downloadDir: string, userTestDir: string, repo: git.Repo, oldTscPath: string, newTscPath: string, outputs: string[]) {
+    const { testType } = params
     if (params.tmpfs)
         await execAsync(processCwd, "sudo mount -t tmpfs -o size=2g tmpfs " + downloadDir);
 
@@ -55,7 +65,7 @@ export async function innerloop(params: Params, downloadDir: string, userTestDir
 
         try {
             console.log("Installing packages if absent");
-            await withTimeout(executionTimeout, installPackages(repoDir, repo.types));
+            await withTimeout(executionTimeout, installPackages(repoDir, /*recursiveSearch*/ testType !== "user", repo.types));
         }
         catch (err) {
             reportError(err, "Error installing packages for " + repo.name);
@@ -65,7 +75,7 @@ export async function innerloop(params: Params, downloadDir: string, userTestDir
 
         try {
             console.log(`Building with ${oldTscPath} (old)`);
-            const oldErrors = await buildAndGetErrors(repoDir, oldTscPath, /*skipLibCheck*/ true, params.postResult);
+            const oldErrors = await buildAndGetErrors(repoDir, oldTscPath, /*skipLibCheck*/ true, testType, params.postResult);
 
             if (oldErrors.hasConfigFailure) {
                 console.log("Unable to build project graph");
@@ -83,6 +93,11 @@ export async function innerloop(params: Params, downloadDir: string, userTestDir
             }
 
             // User tests ignores build failures.
+            if (testType !== "user" && numFailed === numProjects) {
+                console.log(`Skipping build with ${newTscPath} (new)`);
+                return;
+            }
+
             let sawNewRepoErrors = false;
             const owner = repo.owner ? `${repo.owner}/` : "";
             const url = repo.url ? `(${repo.url})` : "";
@@ -96,7 +111,7 @@ export async function innerloop(params: Params, downloadDir: string, userTestDir
             }
 
             console.log(`Building with ${newTscPath} (new)`);
-            const newErrors = await buildAndGetErrors(repoDir, newTscPath, /*skipLibCheck*/ true, params.postResult);
+            const newErrors = await buildAndGetErrors(repoDir, newTscPath, /*skipLibCheck*/ true, testType, params.postResult);
 
             if (newErrors.hasConfigFailure) {
                 console.log("Unable to build project graph");
@@ -109,6 +124,11 @@ export async function innerloop(params: Params, downloadDir: string, userTestDir
 
             console.log("Comparing errors");
             for (const oldProjectErrors of oldErrors.projectErrors) {
+                // To keep things simple, we'll focus on projects that used to build cleanly
+                if (testType !== "user" && (oldProjectErrors.hasBuildFailure || oldProjectErrors.errors.length)) {
+                    continue;
+                }
+
                 // TS 5055 generally indicates that the project can't be built twice in a row without cleaning in between.
                 // Filter out errors reported already on "old".
                 const newProjectErrors = newErrors.projectErrors.find(pe => pe.projectUrl == oldProjectErrors.projectUrl)?.errors?.filter(e => e.code !== 5055)
@@ -172,7 +192,9 @@ export async function innerloop(params: Params, downloadDir: string, userTestDir
     }
 }
 
-export async function mainAsync(params: Params): Promise<git.Result | undefined> {
+export async function mainAsync(params: GitParams | UserParams): Promise<GitResult | UserResult | undefined> {
+    const { testType } = params;
+
     const downloadDir = params.tmpfs ? "/mnt/ts_downloads" : "./ts_downloads";
     // TODO: check first whether the directory exists and skip downloading if possible
     // TODO: Seems like this should come after the typescript download
@@ -193,7 +215,14 @@ export async function mainAsync(params: Params): Promise<git.Result | undefined>
 
     const userTestDir = path.join(processCwd, "userTests");
 
-    const repos = ur.getUserTestsRepos(userTestDir);
+    const repos = testType === "git" ? await git.getPopularTypeScriptRepos(params.repoCount)
+        : testType === "user" ? ur.getUserTestsRepos(userTestDir)
+        : undefined;
+
+    if (!repos) {
+        throw new Error(`Parameter <test_type> with value ${testType} is not existent.`);
+    }
+
     const outputs: string[] = [];
     // let summary = "";
     let sawNewErrors: true | undefined = undefined;
@@ -221,31 +250,43 @@ export async function mainAsync(params: Params): Promise<git.Result | undefined>
         await execAsync(processCwd, "rm -rf " + newTscDirPath);
     }
 
-    const body = summary
-        ? `@${params.requestingUser}\nThe results of the user tests run you requested are in!\n<details><summary> Here they are:</summary><p>\n<b>Comparison Report - ${oldTscResolvedVersion}..${newTscResolvedVersion}</b>\n\n${summary}</p></details>`
-        : `@${params.requestingUser}\nGreat news! no new errors were found between ${oldTscResolvedVersion}..${newTscResolvedVersion}`;
-    return git.createComment(params.sourceIssue, params.statusComment, params.postResult, body);
+    if (testType === "git") {
+        const title = `[NewErrors] ${newTscResolvedVersion} vs ${oldTscResolvedVersion}`;
+        const body = `The following errors were reported by ${newTscResolvedVersion}, but not by ${oldTscResolvedVersion}
+
+${summary}`;
+        return git.createIssue(params.postResult, title, body, !!sawNewErrors);
+    }
+    else if (testType === "user") {
+        const body = summary
+            ? `@${params.requestingUser}\nThe results of the user tests run you requested are in!\n<details><summary> Here they are:</summary><p>\n<b>Comparison Report - ${oldTscResolvedVersion}..${newTscResolvedVersion}</b>\n\n${summary}</p></details>`
+            : `@${params.requestingUser}\nGreat news! no new errors were found between ${oldTscResolvedVersion}..${newTscResolvedVersion}`;
+        return git.createComment(params.sourceIssue, params.statusComment, params.postResult, body);
+    }
+    else {
+        throw new Error(`testType "${(params as any).testType}" is not a recognised test type.`);
+    }
 }
 
-async function buildAndGetErrors(repoDir: string, tscPath: string, skipLibCheck: boolean, realTimeout: boolean): Promise<ge.RepoErrors> {
+async function buildAndGetErrors(repoDir: string, tscPath: string, skipLibCheck: boolean, testType: 'git' | 'user', realTimeout: boolean): Promise<ge.RepoErrors> {
     if (realTimeout) {
         const p = new Promise<ge.RepoErrors>((resolve, reject) => {
             const p = cp.fork(path.join(__dirname, "run-build.js"));
             p.on('message', (m: 'ready' | ge.RepoErrors) =>
                 m === 'ready'
-                    ? p.send({ repoDir, tscPath, skipLibCheck })
+                    ? p.send({ repoDir, tscPath, testType, skipLibCheck })
                     : resolve(m));
             p.on('exit', reject);
         });
         return withTimeout(executionTimeout, p);
     }
     else {
-        return ge.buildAndGetErrors(repoDir, tscPath, skipLibCheck)
+        return ge.buildAndGetErrors(repoDir, tscPath, testType, skipLibCheck)
     }
 }
 
-async function installPackages(repoDir: string, types?: string[]) {
-    const commands = await ip.restorePackages(repoDir, types);
+async function installPackages(repoDir: string, recursiveSearch: boolean, types?: string[]) {
+    const commands = await ip.restorePackages(repoDir, /*ignoreScripts*/ true, recursiveSearch, /*lernaPackages*/ undefined, types);
     let usedYarn = false;
     for (const { directory: packageRoot, tool, arguments: args } of commands) {
         await new Promise<void>((resolve, reject) => {
@@ -345,7 +386,8 @@ function makeMarkdownLink(url: string) {
         : `[${match[1]}](${url})`;
 }
 
-async function downloadTypeScriptAsync(cwd: string, params: Params): Promise<{ oldTscPath: string, oldTscResolvedVersion: string, newTscPath: string, newTscResolvedVersion: string }> {
+async function downloadTypeScriptAsync(cwd: string, params: GitParams | UserParams): Promise<{ oldTscPath: string, oldTscResolvedVersion: string, newTscPath: string, newTscResolvedVersion: string }> {
+    if (params.testType === 'user') {
         const { tscPath: oldTscPath, resolvedVersion: oldTscResolvedVersion } = await downloadTypescriptRepoAsync(cwd, params.oldTypescriptRepoUrl, params.oldHeadRef);
         // We need to handle the ref/pull/*/merge differently as it is not a branch and cannot be pulled during clone.
         const { tscPath: newTscPath, resolvedVersion: newTscResolvedVersion } = await downloadTypescriptSourceIssueAsync(cwd, params.oldTypescriptRepoUrl, params.sourceIssue);
@@ -356,6 +398,21 @@ async function downloadTypeScriptAsync(cwd: string, params: Params): Promise<{ o
             newTscPath,
             newTscResolvedVersion
         };
+    }
+    else if (params.testType === 'git') {
+        const { tscPath: oldTscPath, resolvedVersion: oldTscResolvedVersion } = await downloadTypeScriptNpmAsync(cwd, params.oldTscVersion);
+        const { tscPath: newTscPath, resolvedVersion: newTscResolvedVersion } = await downloadTypeScriptNpmAsync(cwd, params.newTscVersion);
+
+        return {
+            oldTscPath,
+            oldTscResolvedVersion,
+            newTscPath,
+            newTscResolvedVersion
+        };
+    }
+    else {
+        throw new Error('Invalid parameters');
+    }
 }
 
 export async function downloadTypescriptRepoAsync(cwd: string, repoUrl: string, headRef: string): Promise<{ tscPath: string, resolvedVersion: string }> {
@@ -392,4 +449,27 @@ async function buildTsc(repoPath: string) {
     await execAsync(repoPath, "gulp configure-insiders");
     await execAsync(repoPath, "gulp LKG");
     return path.join(repoPath, "built", "local", "tsc.js");
+}
+
+async function downloadTypeScriptNpmAsync(cwd: string, version: string): Promise<{ tscPath: string, resolvedVersion: string }> {
+    const tarName = (await execAsync(cwd, `npm pack typescript@${version} --quiet`)).trim();
+
+    const tarMatch = /^(typescript-(.+))\..+$/.exec(tarName);
+    if (!tarMatch) {
+        throw new Error("Unexpected tarball name format: " + tarName);
+    }
+
+    const resolvedVersion = tarMatch[2];
+    const dirName = tarMatch[1];
+    const dirPath = path.join(processCwd, dirName);
+
+    await execAsync(cwd, `tar xf ${tarName} && rm ${tarName}`);
+    await fs.promises.rename(path.join(processCwd, "package"), dirPath);
+
+    const tscPath = path.join(dirPath, "lib", "tsc.js");
+    if (!await pu.exists(tscPath)) {
+        throw new Error("Cannot find file " + tscPath);
+    }
+
+    return { tscPath, resolvedVersion };
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "license": "MIT",
     "dependencies": {
         "@octokit/rest": "^16.43.2",
+        "@typescript/github-url": "^0.3.2",
         "glob": "^7.1.7",
         "json5": "^2.2.0",
         "simple-git": "^2.39.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@typescript/new-errors",
+    "name": "typescript-error-deltas",
     "version": "0.2.0",
     "description": "Script for comparing the errors from two builds of the TypeScript compiler",
     "main": "index.js",
@@ -15,7 +15,6 @@
     "license": "MIT",
     "dependencies": {
         "@octokit/rest": "^16.43.2",
-        "@typescript/github-url": "^0.3.2",
         "glob": "^7.1.7",
         "json5": "^2.2.0",
         "simple-git": "^2.39.0"

--- a/packageUtils.ts
+++ b/packageUtils.ts
@@ -25,3 +25,62 @@ export function glob(cwd: string, pattern: string): readonly string[] {
 export async function exists(path: string): Promise<boolean> {
     return new Promise(resolve => fs.exists(path, e => resolve(e)));
 }
+
+/**
+ * Heuristically returns a list of package.json paths in lerna dependency order.
+ * NB: Does not actually consume lerna.json.
+ */
+export async function getLernaOrder(repoDir: string): Promise<readonly string[]> {
+    const lernaOrder: string[] = [];
+    const lernaFiles = glob(repoDir, "**/lerna.json");
+    for (const lernaFile of lernaFiles) {
+        const lernaDir = path.dirname(lernaFile);
+        if (await exists(path.join(lernaDir, "packages"))) {
+            const pkgPaths = glob(path.join(lernaDir, "packages"), "**/package.json");
+            const pkgs = await Promise.all(pkgPaths.map(async pkgPath => {
+                const contents = await fs.promises.readFile(pkgPath, { encoding: "utf-8" });
+                const pkg: Package = json5.parse(contents);
+                pkg.meta_dir = path.dirname(pkgPath);
+                pkg.meta_state = "unvisited";
+                return pkg;
+            }));
+            const pkgMap: Record<string, Package | undefined> = {};
+            for (const pkg of pkgs) {
+                pkgMap[pkg.name] = pkg;
+            }
+
+            while (true) {
+                const pkg = pkgs.find(p => p.meta_state === "unvisited");
+                if (!pkg) break;
+                visit(pkg);
+            }
+
+            function visit(pkg: Package): void {
+                // "visiting" indicates a cycle, which lerna allows
+                if (pkg.meta_state !== "unvisited") return;
+
+                pkg.meta_state = "visiting";
+
+                for (const dep in pkg.dependencies) {
+                    const depPkg = pkgMap[dep];
+                    if (depPkg) visit(depPkg);
+                }
+
+                for (const dep in pkg.devDependencies) {
+                    const depPkg = pkgMap[dep];
+                    if (depPkg) visit(depPkg);
+                }
+
+                for (const dep in pkg.peerDependencies) {
+                    const depPkg = pkgMap[dep];
+                    if (depPkg) visit(depPkg);
+                }
+
+                pkg.meta_state = "visited";
+                lernaOrder.push(pkg.meta_dir);
+            }
+        }
+    }
+
+    return lernaOrder;
+}

--- a/run-build.ts
+++ b/run-build.ts
@@ -5,7 +5,7 @@ if (!process.send) process.exit(1);
 
 process.send('ready');
 
-process.on('message', ({repoDir, tscPath, skipLibCheck}) => {
-    ge.buildAndGetErrors(repoDir, tscPath, skipLibCheck)
+process.on('message', ({repoDir, tscPath, testType, skipLibCheck}) => {
+    ge.buildAndGetErrors(repoDir, tscPath, testType, skipLibCheck)
       .then(r => { process.send!(r), process.exit(); });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
         "sourceMap": true,
     },
     "include": [
-        "*.ts"
+        "*.ts", "github-url/*.ts"
     ],
     "exclude": [
         "userTests", "typescript-*"

--- a/userErrors.ts
+++ b/userErrors.ts
@@ -9,6 +9,7 @@ if (argv.length !== 8) {
 }
 
 mainAsync({
+    testType: "user",
     postResult: argv[2].toLowerCase() === "true", // Only accept true.
     tmpfs: true,
     oldTypescriptRepoUrl: argv[3],


### PR DESCRIPTION
This reverts the commit that removed git tests, plus inlines the code [from `@typescript/github-url`](https://devdiv.visualstudio.com/NodeRepos/_git/typescript__github-url). 

This does not set up the pipelines.yml file to be correct. I'm going to do that in a separate step. First I want to make sure that `user test inline` still works with all the old code back in place.