### PR TITLE
Fix skipping projects after first failure

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -235,7 +235,9 @@ export async function mainAsync(params: GitParams | UserParams): Promise<GitResu
         i++;
         if (i > maxCount) break;
         console.log(`Starting #${i} / ${maxCount}: ${repo.url ?? repo.name}`);
-        sawNewErrors = sawNewErrors || await innerloop(params, downloadDir, userTestDir, repo, oldTscPath, newTscPath, outputs)
+        if (await innerloop(params, downloadDir, userTestDir, repo, oldTscPath, newTscPath, outputs)) {
+            sawNewErrors = true;
+        }
     }
     const summary = outputs.join("")
 


### PR DESCRIPTION
This is a pretty simple error that wasn't nearly as noticeable on the user tests because most PRs *don't* break the user tests, and if they do so only introduce one error.