### PR TITLE
Add top 100 repos mode to user tests

### DIFF
--- a/azure-pipelines-userTests.yml
+++ b/azure-pipelines-userTests.yml
@@ -3,6 +3,10 @@ parameters:
     displayName: Post GitHub comment with results
     type: boolean
     default: true
+  - name: TOP_REPOS
+    displayName: Query Github for top TS repos by stars
+    type: boolean
+    default: false
   - name: OLD_TS_REPO_URL
     displayName: Old Typscript Repo Url
     type: string
@@ -37,6 +41,6 @@ jobs:
   - script: |
       npm ci
       npm run build
-      node userErrors ${{ parameters.POST_RESULT }} ${{ parameters.OLD_TS_REPO_URL }} ${{ parameters.OLD_HEAD_REF }} ${{ parameters.REQUESTING_USER }} ${{ parameters.SOURCE_ISSUE }} ${{ parameters.STATUS_COMMENT }}
+      node userErrors ${{ parameters.POST_RESULT }} ${{ parameters.OLD_TS_REPO_URL }} ${{ parameters.OLD_HEAD_REF }} ${{ parameters.REQUESTING_USER }} ${{ parameters.SOURCE_ISSUE }} ${{ parameters.STATUS_COMMENT }} ${{ parameters.TOP_REPOS }}
     env:
       GITHUB_PAT: $(GITHUB_PAT)

--- a/main.ts
+++ b/main.ts
@@ -256,11 +256,10 @@ export async function mainAsync(params: GitParams | UserParams): Promise<GitResu
     if (testType === "git") {
         const title = `[NewErrors] ${newTscResolvedVersion} vs ${oldTscResolvedVersion}`;
         const body = `The following errors were reported by ${newTscResolvedVersion}, but not by ${oldTscResolvedVersion}
-
-${summary}
-
 [Pipeline that generated this bug](https://typescript.visualstudio.com/TypeScript/_build?definitionId=48)
-[File that generated the pipeline](https://github.com/microsoft/typescript-error-deltas/blob/main/azure-pipelines-gitTests.yml)`;
+[File that generated the pipeline](https://github.com/microsoft/typescript-error-deltas/blob/main/azure-pipelines-gitTests.yml)
+
+${summary}`;
         return git.createIssue(params.postResult, title, body, !!sawNewErrors);
     }
     else if (testType === "user") {

--- a/main.ts
+++ b/main.ts
@@ -15,7 +15,7 @@ interface Params {
     tmpfs: boolean;
     /**
      * Number of repos to test, undefined for the default.
-     * Git repos are chosen randomly; default is 100.
+     * Git repos are chosen from Typescript-language repos based on number of stars; default is 100.
      * User repos start at the top of the list; default is all of them.
      */
     repoCount?: number | undefined;
@@ -32,6 +32,7 @@ export interface UserParams extends Params {
     sourceIssue: number;
     requestingUser: string;
     statusComment: number;
+    topRepos: boolean;
 }
 
 const skipRepos = [
@@ -215,7 +216,7 @@ export async function mainAsync(params: GitParams | UserParams): Promise<GitResu
 
     const userTestDir = path.join(processCwd, "userTests");
 
-    const repos = testType === "git" ? await git.getPopularTypeScriptRepos(params.repoCount)
+    const repos = testType === "git" || params.topRepos ? await git.getPopularTypeScriptRepos(params.repoCount)
         : testType === "user" ? ur.getUserTestsRepos(userTestDir)
         : undefined;
 
@@ -256,7 +257,10 @@ export async function mainAsync(params: GitParams | UserParams): Promise<GitResu
         const title = `[NewErrors] ${newTscResolvedVersion} vs ${oldTscResolvedVersion}`;
         const body = `The following errors were reported by ${newTscResolvedVersion}, but not by ${oldTscResolvedVersion}
 
-${summary}`;
+${summary}
+
+[Pipeline that generated this bug](https://typescript.visualstudio.com/TypeScript/_build?definitionId=48)
+[File that generated the pipeline](https://github.com/microsoft/typescript-error-deltas/blob/main/azure-pipelines-gitTests.yml)`;
         return git.createIssue(params.postResult, title, body, !!sawNewErrors);
     }
     else if (testType === "user") {

--- a/userErrors.ts
+++ b/userErrors.ts
@@ -3,8 +3,8 @@ import { mainAsync, reportError } from "./main";
 
 const { argv } = process;
 
-if (argv.length !== 8) {
-    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <post_result> <old_typescript_repo_url> <old_head_ref> <requesting_user> <source_issue> <status_comment>`);
+if (argv.length !== 9) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <post_result> <old_typescript_repo_url> <old_head_ref> <requesting_user> <source_issue> <status_comment> <top_repos>`);
     process.exit(-1);
 }
 
@@ -16,7 +16,8 @@ mainAsync({
     oldHeadRef: argv[4],
     requestingUser: argv[5],
     sourceIssue: +argv[6], // Github's pr ID number.
-    statusComment: +argv[7]
+    statusComment: +argv[7],
+    topRepos: argv[8].toLowerCase() === "true" // Only accept true.
 }).catch(err => {
     reportError(err, "Unhandled exception");
     process.exit(1);


### PR DESCRIPTION
Choose repos the same way as DetectNewErrors, but otherwise is the same as `user test this inline`

Also: the issue filed now has links back to the pipeline and its source code.

Followed up by https://github.com/weswigham/typescript-bot-test-triggerer/pull/18