### PR TITLE
Support a start index for repos on the git NewErrors detector.

### DIFF
--- a/azure-pipelines-gitTests.yml
+++ b/azure-pipelines-gitTests.yml
@@ -7,6 +7,10 @@ parameters:
     displayName: Repo Count
     type: string
     default: 100
+  - name: REPO_START_INDEX
+    displayName: Repo Start Index
+    type: string
+    default: 0
   - name: OLD_VERSION
     displayName: Baseline typescript package version
     type: string
@@ -41,6 +45,6 @@ jobs:
   - script: |
       npm ci
       npm run build
-      node gitErrors ${{ parameters.POST_RESULT }} ${{ parameters.REPO_COUNT }} ${{ parameters.OLD_VERSION }} ${{ parameters.NEW_VERSION }}
+      node gitErrors ${{ parameters.POST_RESULT }} ${{ parameters.REPO_COUNT }} ${{ parameters.REPO_START_INDEX }} ${{ parameters.OLD_VERSION }} ${{ parameters.NEW_VERSION }}
     env:
       GITHUB_PAT: $(GITHUB_PAT)

--- a/gitErrors.ts
+++ b/gitErrors.ts
@@ -3,18 +3,21 @@ import { mainAsync, reportError } from "./main";
 
 const { argv } = process;
 
-if (argv.length !== 6) {
-    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <post_result> <repo_count> <old_tsc_version> <new_tsc_version>`);
+if (argv.length !== 7) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <post_result> <repo_count> <repo_start_index> <old_tsc_version> <new_tsc_version>`);
     process.exit(-1);
 }
 
+const [,, postResultStr, repoCountStr, repoStartIndexStr, oldTscVersion, newTscVersion] = argv;
+
 mainAsync({
     testType: "git",
-    postResult: argv[2].toLowerCase() === "true", // Only accept true.
+    postResult: postResultStr.toLowerCase() === "true", // Only accept true.
     tmpfs: true,
-    repoCount: +argv[3],
-    oldTscVersion: argv[4],
-    newTscVersion: argv[5],
+    repoCount: +repoCountStr,
+    repoStartIndex: +repoStartIndexStr,
+    oldTscVersion,
+    newTscVersion,
 }).catch(err => {
     reportError(err, "Unhandled exception");
     process.exit(1);

--- a/gitUtils.ts
+++ b/gitUtils.ts
@@ -18,7 +18,7 @@ const repoProperties = {
     repo: "typescript",
 };
 
-export async function getPopularTypeScriptRepos(count = 100, cachePath?: string): Promise<readonly Repo[]> {
+export async function getPopularTypeScriptRepos(count = 100, repoStartIndex: number = 0, cachePath?: string): Promise<readonly Repo[]> {
     const cacheEncoding = { encoding: "utf-8" } as const;
 
     if (cachePath && await utils.exists(cachePath)) {
@@ -41,10 +41,22 @@ export async function getPopularTypeScriptRepos(count = 100, cachePath?: string)
             per_page: perPage,
             page,
         });
+        
+        let items = response.data.items;
+        if (repoStartIndex > 0) {
+            if (repoStartIndex < items.length) {
+                items = items.slice(repoStartIndex);
+                repoStartIndex = 0;
+            }
+            else {
+                repoStartIndex -= items.length;
+                continue;
+            }
+        }
 
         if (response.status !== 200) throw response;
 
-        for (const repo of response.data.items) {
+        for (const repo of items) {
             if (repo.full_name !== "microsoft/TypeScript" && repo.full_name !== "DefinitelyTyped/DefinitelyTyped") {
                 repos.push({ url: repo.html_url, name: repo.name, owner: repo.owner.login });
             }

--- a/gitUtils.ts
+++ b/gitUtils.ts
@@ -18,7 +18,7 @@ const repoProperties = {
     repo: "typescript",
 };
 
-export async function getPopularTypeScriptRepos(count = 100, repoStartIndex: number = 0, cachePath?: string): Promise<readonly Repo[]> {
+export async function getPopularTypeScriptRepos(count = 100, repoStartIndex = 0, cachePath?: string): Promise<readonly Repo[]> {
     const cacheEncoding = { encoding: "utf-8" } as const;
 
     if (cachePath && await utils.exists(cachePath)) {

--- a/main.ts
+++ b/main.ts
@@ -19,11 +19,11 @@ interface Params {
      * User repos start at the top of the list; default is all of them.
      */
      repoCount?: number | undefined;
-     /**
-      * The index to start counting repositories; defaults to `0`.
-      * If `repoStartIndex` is 99 and `repoCount` is 100, the 100th to the 199th repos will be tested.
-      */
-     repoStartIndex?: number | undefined;
+    /**
+     * The index to start counting repositories; defaults to `0`.
+     * If `repoStartIndex` is 99 and `repoCount` is 100, the 100th to the 199th repos will be tested.
+     */
+    repoStartIndex?: number | undefined;
 }
 export interface GitParams extends Params {
     testType: 'git';

--- a/main.ts
+++ b/main.ts
@@ -18,7 +18,7 @@ interface Params {
      * Git repos are chosen from Typescript-language repos based on number of stars; default is 100.
      * User repos start at the top of the list; default is all of them.
      */
-     repoCount?: number | undefined;
+    repoCount?: number | undefined;
     /**
      * The index to start counting repositories; defaults to `0`.
      * If `repoStartIndex` is 99 and `repoCount` is 100, the 100th to the 199th repos will be tested.


### PR DESCRIPTION
This PR introduces a new parameter, `REPO_START_INDEX`, which will allow you to specify an offset for repos to start at. So the idea is that if you want to run on the second top 100 repos (i.e. the 100th through 199th instead of the 0th through 99th), you could run with a `REPO_COUNT` of `100`, with a `REPO_START_INDEX` of `100`.