### PR TITLE
Tweaks based on test run after dependency update

### DIFF
--- a/gitUtils.ts
+++ b/gitUtils.ts
@@ -1,9 +1,11 @@
 import octokit = require("@octokit/rest");
 import utils = require("./packageUtils");
-import git = require("simple-git/promise");
 import fs = require("fs");
 import path = require("path");
 import cp = require("child_process");
+
+// The bundled types don't work with CJS imports
+import { simpleGit as git } from "simple-git";
 
 export interface Repo {
     name: string;
@@ -41,7 +43,7 @@ export async function getPopularTypeScriptRepos(count = 100, repoStartIndex = 0,
             per_page: perPage,
             page,
         });
-        
+
         let items = response.data.items;
         if (repoStartIndex > 0) {
             if (repoStartIndex < items.length) {
@@ -147,7 +149,7 @@ export async function createComment(sourceIssue: number, statusComment: number, 
     }
 
     console.log("Creating a github comment");
-    
+
     const kit = new octokit.Octokit({
         auth: process.env.GITHUB_PAT,
     });

--- a/main.ts
+++ b/main.ts
@@ -75,7 +75,7 @@ export async function innerloop(params: GitParams | UserParams, topGithubRepos: 
             await withTimeout(executionTimeout, installPackages(repoDir, /*recursiveSearch*/ topGithubRepos, repo.types));
         }
         catch (err) {
-            reportError(err, "Error installing packages for " + repo.name);
+            reportError(err, `Error installing packages for ${err.packageRoot ?? "some package.json file"} in ${repo.name}`);
             await reportResourceUsage(downloadDir);
             return;
         }
@@ -304,7 +304,7 @@ async function installPackages(repoDir: string, recursiveSearch: boolean, types?
     for (const { directory: packageRoot, tool, arguments: args } of commands) {
         await new Promise<void>((resolve, reject) => {
             usedYarn = usedYarn || tool === ip.InstallTool.Yarn;
-            cp.execFile(tool, args, { cwd: packageRoot }, err => err ? reject(err) : resolve());
+            cp.execFile(tool, args, { cwd: packageRoot }, err => err ? reject({...err, packageRoot}) : resolve());
         });
     }
     if (usedYarn) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         "skipLibCheck": true,
         "declaration": true,
         "sourceMap": true,
+        "useUnknownInCatchVariables": false,
     },
     "include": [
         "*.ts", "github-url/*.ts"


### PR DESCRIPTION
- `simple-git` changed their preferred calling pattern
- "Failed to restore" error messages should indicate which package