### PR TITLE
Fix common package installation errors

### DIFF
--- a/src/execUtils.ts
+++ b/src/execUtils.ts
@@ -20,31 +20,50 @@ export async function execAsync(cwd: string, command: string): Promise<string> {
     });
 }
 
-export interface ExecFileResult {
-    err: cp.ExecException | null,
+export interface SpawnResult {
     stdout: string,
     stderr: string,
+    code: number | null,
+    signal: NodeJS.Signals | null,
 }
 
 /** Returns undefined if and only if executions times out. */
-export function execFileWithTimeoutAsync(cwd: string, command: string, args: readonly string[], timeoutMs: number, env?: {}): Promise<ExecFileResult | undefined> {
-    return new Promise<ExecFileResult | undefined>((resolve, _reject) => {
-        let timedOut = false;
+export function spawnWithTimeoutAsync(cwd: string, command: string, args: readonly string[], timeoutMs: number, env?: {}): Promise<SpawnResult | undefined> {
+    return new Promise<SpawnResult | undefined>((resolve, _reject) => {
+        if (timeoutMs <= 0) {
+            resolve(undefined);
+            return;
+        }
 
-        const childProcess = cp.execFile(command, args, { cwd, env }, (err, stdout, stderr) => {
-            if (!timedOut) {
-                clearTimeout(timeout);
-                resolve({ err, stdout, stderr } as const);
-            }
+        // We use `spawn`, rather than `execFile`, because package installation tends to write a lot
+        // of data to stdout, overflowing `execFile`'s buffer.
+        const childProcess = cp.spawn(command, args, {
+            cwd,
+            env,
+            windowsHide: true,
+            timeout: timeoutMs | 0, // Truncate to integer for spawn
         });
 
-        const timeout = setTimeout(async () => {
-            timedOut = true;
-            await execAsync(path.join(__dirname, "..", "scripts"), `./kill-children-of ${childProcess.pid}`);
-            if (!childProcess.kill()) {
-                console.log(`Failed to kill ${childProcess.pid}`);
+        let stdout = "";
+        let stderr = "";
+
+        childProcess.stdout.on("data", data => {
+            stdout += data;
+        });
+
+        childProcess.stderr.on("data", data => {
+            stderr += data;
+        });
+
+        childProcess.on("close", async (code, signal) => {
+            // SIGTERM indicates timeout
+            if (signal === "SIGTERM") {
+                await execAsync(path.join(__dirname, "..", "scripts"), `./kill-children-of ${childProcess.pid}`);
+                resolve(undefined);
+                return;
             }
-            resolve(undefined);
-        }, timeoutMs);
+
+            resolve({ stdout, stderr, code, signal });
+        });
     });
 }

--- a/src/installPackages.ts
+++ b/src/installPackages.ts
@@ -52,7 +52,7 @@ export async function restorePackages(repoDir: string, ignoreScripts: boolean = 
         let args: string[];
 
         const isProjectYarn2 = isRepoYarn2 || await utils.exists(path.join(packageRoot, ".yarnrc.yml"));
-        if (await utils.exists(path.join(packageRoot, "yarn.lock"))) {
+        if (isProjectYarn2 || await utils.exists(path.join(packageRoot, "yarn.lock"))) {
             tool = InstallTool.Yarn;
 
             // Yarn 2 dropped support for most `install` arguments

--- a/src/installPackages.ts
+++ b/src/installPackages.ts
@@ -58,6 +58,10 @@ export async function restorePackages(repoDir: string, ignoreScripts: boolean = 
             // Yarn 2 dropped support for most `install` arguments
             if (isProjectYarn2) {
                 args = ["install"]
+
+                if (ignoreScripts) {
+                    args.push("--mode=skip-build");
+                }
             }
             else {
                 args = ["install", "--silent", "--ignore-engines"];
@@ -73,7 +77,7 @@ export async function restorePackages(repoDir: string, ignoreScripts: boolean = 
             const haveLock = await utils.exists(path.join(packageRoot, "package-lock.json")) ||
                 await hasCurrentShrinkwrap(packageRoot);
 
-            args = [haveLock ? "ci" : "install", "--prefer-offline", "--no-audit", "-q", "--no-progress"];
+            args = [haveLock ? "ci" : "install", "--prefer-offline", "--no-audit", "-q", "--no-progress", "--legacy-peer-deps"];
 
             if (ignoreScripts) {
                 args.push("--ignore-scripts");
@@ -90,9 +94,13 @@ export async function restorePackages(repoDir: string, ignoreScripts: boolean = 
         });
 
         if (types && types.length > 0) {
-            const args = isProjectYarn2
-                ? ["install", ...types.map(t => `@types/${t}`), "--ignore-scripts"]
-                : ["install", ...types.map(t => `@types/${t}`), "--no-save", "--ignore-scripts", "--legacy-peer-deps"]
+            // `types` is only present for user tests and all known user tests use npm, not yarn
+            const typesPackageNames = types.map(t => `@types/${t}`);
+            const args = tool === InstallTool.Npm
+                ? ["install", ...typesPackageNames, "--no-save", "--ignore-scripts", "--legacy-peer-deps"]
+                : isProjectYarn2
+                    ? ["install", ...typesPackageNames, "--mode=skip-build"]
+                    : ["install", ...typesPackageNames, "--silent", "--ignore-engines", "--ignore-scripts" ]
 
             commands.push({
                 directory: packageRoot,

--- a/src/main.ts
+++ b/src/main.ts
@@ -378,7 +378,9 @@ async function installPackages(repoDir: string, recursiveSearch: boolean, timeou
             const err: any = execResult
                 ? execResult.err
                 : new Error(`Timed out after ${timeoutMs} ms`);
-            if (err) {
+            // If the file doesn't parse, installing its dependencies can't be important for correctness
+            // (This mostly happens in example files)
+            if (err && !(tool === ip.InstallTool.Npm && err.toString().indexOf("EJSONPARSE") >= 0)) {
                 err.message = `Failed to install packages for ${packageRootDescription}: ${err.message}`;
                 throw err;
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import ge = require("./getErrors");
 import pu = require("./packageUtils");
 import git = require("./gitUtils");
-import { execAsync, execFileWithTimeoutAsync } from "./execUtils";
+import { execAsync, spawnWithTimeoutAsync } from "./execUtils";
 import type { GitResult, UserResult } from "./gitUtils";
 import ip = require("./installPackages");
 import ut = require("./userTestUtils");
@@ -374,34 +374,36 @@ async function installPackages(repoDir: string, recursiveSearch: boolean, timeou
             const packageRootDescription = packageRoot.substring(repoDir.length + 1) || "root directory";
 
             // yarn2 produces extremely verbose output unless CI=true is set and it should be harmless for yarn1 and npm
-            const execResult = await execFileWithTimeoutAsync(packageRoot, tool, args, timeoutMs - elapsedMs, {...process.env, CI: "true" });
-            const err: any = execResult
-                ? execResult.err
-                : new Error(`Timed out after ${timeoutMs} ms`);
+            const spawnResult = await spawnWithTimeoutAsync(packageRoot, tool, args, timeoutMs - elapsedMs, { ...process.env, CI: "true" });
+            if (!spawnResult) {
+                throw new Error(`Timed out after ${timeoutMs} ms`);
+            }
 
-            if (err) {
-                err.message = `Failed to install packages for ${packageRootDescription}: ${err.message}`;
-
-                if (tool === ip.InstallTool.Npm && args[0] === "ci" && /update your lock file/.test(err.toString())) {
+            if (spawnResult.code || spawnResult.signal) {
+                if (tool === ip.InstallTool.Npm && args[0] === "ci" && /update your lock file/.test(spawnResult.stderr)) {
                     const elapsedMs2 = performance.now() - startMs;
                     const args2 = args.slice();
                     args2[0] = "install";
-                    const execResult2 = await execFileWithTimeoutAsync(packageRoot, tool, args2, timeoutMs - elapsedMs2, {...process.env, CI: "true" });
-                    if (execResult2 && !execResult2.err) {
+                    const spawnResult2 = await spawnWithTimeoutAsync(packageRoot, tool, args2, timeoutMs - elapsedMs2, { ...process.env, CI: "true" });
+                    if (spawnResult2 && !spawnResult2.code && !spawnResult2.signal) {
                         continue; // Succeeded on retry
                     }
                 }
 
-                if ((tool === ip.InstallTool.Npm && /EJSONPARSE/.test(err.toString()))) {
+                const errorText = tool == ip.InstallTool.Yarn ? spawnResult.stdout : spawnResult.stderr;
+
+                if ((tool === ip.InstallTool.Npm && /EJSONPARSE/.test(errorText))) {
                     // If the file doesn't parse, installing its dependencies can't be important for correctness
                     // (This mostly happens in example files)
-                    reportError(err, `Ignoring package install parsing error`);
+                    console.log("Ignoring package install parsing error:");
+                    console.log(errorText);
                 }
                 else if (/\/(?:ex|s)amples?\//.test(packageRoot)) {
-                    reportError(err, `Ignoring package install error from sample folder`);
+                    console.log("Ignoring package install error from sample folder:");
+                    console.log(errorText);
                 }
                 else {
-                    throw err;
+                    throw new Error(`Failed to install packages for ${packageRootDescription}:\n${errorText}`);
                 }
             }
         }
@@ -431,8 +433,17 @@ async function reportResourceUsage(downloadDir: string) {
 
 export function reportError(err: any, message: string) {
     console.log(`${message}:`);
-    console.log(reduceSpew(err.message ?? "No message").replace(/(^|\n)/g, "$1> "));
-    console.log(reduceSpew(err.stack ?? "Unknown Stack").replace(/(^|\n)/g, "$1> "));
+    if (err.message && err.stack && err.stack.indexOf(err.message) >= 0) {
+        console.log(sanitizeErrorText(err.stack));
+    }
+    else {
+        console.log(sanitizeErrorText(err.message ?? "No message"));
+        console.log(sanitizeErrorText(err.stack ?? "Unknown Stack"));
+    }
+}
+
+function sanitizeErrorText(text: string): string {
+    return reduceSpew(text).replace(/(^|\n)/g, "$1> ");
 }
 
 function reduceSpew(message: string): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -373,7 +373,8 @@ async function installPackages(repoDir: string, recursiveSearch: boolean, timeou
             const elapsedMs = performance.now() - startMs;
             const packageRootDescription = packageRoot.substring(repoDir.length + 1) || "root directory";
 
-            const execResult = await execFileWithTimeoutAsync(packageRoot, tool, args, timeoutMs - elapsedMs);
+            // yarn2 produces extremely verbose output unless CI=true is set and it should be harmless for yarn1 and npm
+            const execResult = await execFileWithTimeoutAsync(packageRoot, tool, args, timeoutMs - elapsedMs, {...process.env, CI: "true" });
             const err: any = execResult
                 ? execResult.err
                 : new Error(`Timed out after ${timeoutMs} ms`);


### PR DESCRIPTION
- Ignore failure to parse package.json
- Ignore failures in example/sample projects
- Use spawn, rather than execFile, to accommodate very long output
- Set `CI=true` to shorten yarn output
- Stop using npm in some yarn 2 scenarios
- Retry with install when npm ci fails due to an out-of-date lockfile