### PR TITLE
Add basic pnpm support

### DIFF
--- a/src/installPackages.ts
+++ b/src/installPackages.ts
@@ -95,12 +95,9 @@ export async function restorePackages(repoDir: string, ignoreScripts: boolean = 
 
         if (types && types.length > 0) {
             // `types` is only present for user tests and all known user tests use npm, not yarn
+            // Besides, we're using --no-save, so it shouldn't matter which tool we use
             const typesPackageNames = types.map(t => `@types/${t}`);
-            const args = tool === InstallTool.Npm
-                ? ["install", ...typesPackageNames, "--no-save", "--ignore-scripts", "--legacy-peer-deps"]
-                : isProjectYarn2
-                    ? ["install", ...typesPackageNames, "--mode=skip-build"]
-                    : ["install", ...typesPackageNames, "--silent", "--ignore-engines", "--ignore-scripts" ]
+            const args = ["install", ...typesPackageNames, "--no-save", "--ignore-scripts", "--legacy-peer-deps"];
 
             commands.push({
                 directory: packageRoot,

--- a/src/installPackages.ts
+++ b/src/installPackages.ts
@@ -9,6 +9,7 @@ import utils = require("./packageUtils");
 export enum InstallTool {
     Npm = "npm",
     Yarn = "yarn",
+    Pnpm = "pnpm",
 }
 
 export interface InstallCommand {
@@ -26,6 +27,7 @@ export async function restorePackages(repoDir: string, ignoreScripts: boolean = 
 
     // The existence of .yarnrc.yml indicates that this repo uses yarn 2
     const isRepoYarn2 = await utils.exists(path.join(repoDir, ".yarnrc.yml"));
+    const isRepoPnpm = await utils.exists(path.join(repoDir, "pnpm-lock.yaml"));
 
     const commands: InstallCommand[] = [];
 
@@ -70,6 +72,15 @@ export async function restorePackages(repoDir: string, ignoreScripts: boolean = 
                     args.push("--ignore-scripts");
                 }
             }
+        }
+        else if (isRepoPnpm || await utils.exists(path.join(packageRoot, "pnpm-lock.yaml"))) {
+            tool = InstallTool.Pnpm;
+            args = ["install", "--prefer-offline", "--reporter=silent"];
+
+            if (ignoreScripts) {
+                args.push("--ignore-scripts");
+            }
+
         }
         else if (await utils.exists(path.join(packageRoot, "package.json"))) {
             tool = InstallTool.Npm;

--- a/src/main.ts
+++ b/src/main.ts
@@ -388,13 +388,7 @@ async function installPackages(repoDir: string, recursiveSearch: boolean, timeou
 
                 const errorText = tool == ip.InstallTool.Yarn ? spawnResult.stdout : spawnResult.stderr;
 
-                if ((tool === ip.InstallTool.Npm && /EJSONPARSE/.test(errorText))) {
-                    // If the file doesn't parse, installing its dependencies can't be important for correctness
-                    // (This mostly happens in example files)
-                    console.log("Ignoring package install parsing error:");
-                    console.log(sanitizeErrorText(errorText));
-                }
-                else if (/\/(?:ex|s)amples?\//.test(packageRoot)) {
+                if (/\/(?:ex|s)amples?\//.test(packageRoot)) {
                     console.log("Ignoring package install error from sample folder:");
                     console.log(sanitizeErrorText(errorText));
                 }


### PR DESCRIPTION
There's a pretty good chance the pipeline machines won't have `pnpm` and some adjustments will be required.  Having said that, there's probably no reason to roll this back if pnpm is absent because package installation would have failed for those repos anyway.