### PR TITLE
Fix User Test errors

### DIFF
--- a/src/installPackages.ts
+++ b/src/installPackages.ts
@@ -51,6 +51,11 @@ export async function restorePackages(repoDir: string, ignoreScripts: boolean, q
 
         const packageRoot = path.dirname(packageFile);
 
+        // Heuristic, these are rarely valuable and often fail.
+        if (/fixtures?/i.test(packageRoot)) {
+            continue;
+        }
+
         let tool: InstallTool;
         let args: string[];
 
@@ -128,7 +133,7 @@ export async function restorePackages(repoDir: string, ignoreScripts: boolean, q
 
             commands.push({
                 directory: packageRoot,
-                tool,
+                tool: InstallTool.Npm,
                 arguments: args
             });
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -428,8 +428,8 @@ async function installPackages(repoDir: string, recursiveSearch: boolean, timeou
                 const errorText = `Exited with ${spawnResult.code ? `code ${spawnResult.code}` : `signal ${spawnResult.signal}`}
 ${spawnResult.stdout.trim() || "No stdout"}\n${spawnResult.stderr.trim() || "No stderr"}`;
 
-                if (/(?:ex|s)amples?\//.test(packageRoot)) {
-                    console.log(`Ignoring package install error from sample folder ${packageRoot}:`);
+                if (/(?:ex|s)amples?\//i.test(packageRootDescription) || /tests?\//i.test(packageRootDescription)) {
+                    console.log(`Ignoring package install error from non-product folder ${packageRootDescription}:`);
                     console.log(sanitizeErrorText(errorText));
                 }
                 else {


### PR DESCRIPTION
1. Ignore package.json files in fixture folders
2. Ignore package installation failures in test folders
3. Always use npm for installing @types packages