### PR TITLE
Parallelize pipelines

### DIFF
--- a/azure-pipelines-gitTests.yml
+++ b/azure-pipelines-gitTests.yml
@@ -55,7 +55,7 @@ jobs:
       GITHUB_PAT: $(GITHUB_PAT)
   - publish: artifacts
     artifact: RepoList
-- job: 'DetectNewErrors'
+- job: DetectNewErrors
   dependsOn: ListRepos
   timeoutInMinutes: 360
   steps:
@@ -69,6 +69,26 @@ jobs:
       npm ci
       npm run build
       npm install -g pnpm
-      node dist/gitErrors ${{ parameters.POST_RESULT }} ${{ parameters.OLD_VERSION }} ${{ parameters.NEW_VERSION }} '$(Pipeline.Workspace)/RepoList/repos.json' ${{ parameters.DIAGNOSTIC_OUTPUT }}
+      mkdir artifacts
+      node dist/gitErrors ${{ parameters.OLD_VERSION }} ${{ parameters.NEW_VERSION }} '$(Pipeline.Workspace)/RepoList/repos.json' './artifacts' ${{ parameters.DIAGNOSTIC_OUTPUT }}
+    displayName: 'Run tsc on repos'
+    env:
+      GITHUB_PAT: $(GITHUB_PAT)
+  - publish: artifacts
+    artifact: RepoResults
+- job: ReportNewErrors
+  dependsOn: DetectNewErrors
+  steps:
+  - download: current
+    artifact: RepoResults
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '16.x'
+    displayName: 'Install Node.js'
+  - script: |
+      npm ci
+      npm run build
+      node dist/createGhIssue ${{ parameters.REPO_COUNT }} ${{ parameters.REPO_START_INDEX }} '$(Pipeline.Workspace)' ${{ parameters.POST_RESULT }}
+    displayName: 'Create issue from new errors'
     env:
       GITHUB_PAT: $(GITHUB_PAT)

--- a/azure-pipelines-gitTests.yml
+++ b/azure-pipelines-gitTests.yml
@@ -9,11 +9,11 @@ parameters:
     default: false
   - name: REPO_COUNT
     displayName: Repo Count
-    type: string
-    default: 100
+    type: number
+    default: 200
   - name: REPO_START_INDEX
     displayName: Repo Start Index
-    type: string
+    type: number
     default: 0
   - name: OLD_VERSION
     displayName: Baseline typescript package version
@@ -23,6 +23,15 @@ parameters:
     displayName: Candidate typescript package version
     type: string
     default: next
+  - name: MACHINE_COUNT
+    displayName: Machine Count
+    type: number
+    default: 4
+    values:
+    - 1
+    - 2
+    - 4
+    - 8
 
 schedules:
   - cron: "0 18 * * Sun" # time is in UTC
@@ -57,7 +66,10 @@ jobs:
     artifact: RepoList
 - job: DetectNewErrors
   dependsOn: ListRepos
+  continueOnError: true
   timeoutInMinutes: 360
+  strategy:
+    parallel: ${{ parameters.MACHINE_COUNT }}
   steps:
   - download: current
     artifact: RepoList
@@ -70,17 +82,16 @@ jobs:
       npm run build
       npm install -g pnpm
       mkdir artifacts
-      node dist/gitErrors ${{ parameters.OLD_VERSION }} ${{ parameters.NEW_VERSION }} '$(Pipeline.Workspace)/RepoList/repos.json' './artifacts' ${{ parameters.DIAGNOSTIC_OUTPUT }}
+      node dist/gitErrors ${{ parameters.OLD_VERSION }} ${{ parameters.NEW_VERSION }} '$(Pipeline.Workspace)/RepoList/repos.json' $(System.TotalJobsInPhase) $(System.JobPositionInPhase) './artifacts' ${{ parameters.DIAGNOSTIC_OUTPUT }}
     displayName: 'Run tsc on repos'
     env:
       GITHUB_PAT: $(GITHUB_PAT)
   - publish: artifacts
-    artifact: RepoResults
+    artifact: 'RepoResults$(System.JobPositionInPhase)'
 - job: ReportNewErrors
   dependsOn: DetectNewErrors
   steps:
   - download: current
-    artifact: RepoResults
   - task: NodeTool@0
     inputs:
       versionSpec: '16.x'

--- a/azure-pipelines-gitTests.yml
+++ b/azure-pipelines-gitTests.yml
@@ -39,8 +39,7 @@ pool:
   vmImage: 'ubuntu-latest'
 
 jobs:
-- job: 'DetectNewErrors'
-  timeoutInMinutes: 360
+- job: ListRepos
   steps:
   - task: NodeTool@0
     inputs:
@@ -49,7 +48,27 @@ jobs:
   - script: |
       npm ci
       npm run build
+      mkdir artifacts
+      node dist/listTopRepos TypeScript ${{ parameters.REPO_COUNT }} ${{ parameters.REPO_START_INDEX }} artifacts/repos.json
+    displayName: 'List top TS repos'
+    env:
+      GITHUB_PAT: $(GITHUB_PAT)
+  - publish: artifacts
+    artifact: RepoList
+- job: 'DetectNewErrors'
+  dependsOn: ListRepos
+  timeoutInMinutes: 360
+  steps:
+  - download: current
+    artifact: RepoList
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '16.x'
+    displayName: 'Install Node.js'
+  - script: |
+      npm ci
+      npm run build
       npm install -g pnpm
-      node dist/gitErrors ${{ parameters.POST_RESULT }} ${{ parameters.REPO_COUNT }} ${{ parameters.REPO_START_INDEX }} ${{ parameters.OLD_VERSION }} ${{ parameters.NEW_VERSION }} ${{ parameters.DIAGNOSTIC_OUTPUT }}
+      node dist/gitErrors ${{ parameters.POST_RESULT }} ${{ parameters.OLD_VERSION }} ${{ parameters.NEW_VERSION }} '$(Pipeline.Workspace)/RepoList/repos.json' ${{ parameters.DIAGNOSTIC_OUTPUT }}
     env:
       GITHUB_PAT: $(GITHUB_PAT)

--- a/azure-pipelines-userTests.yml
+++ b/azure-pipelines-userTests.yml
@@ -36,8 +36,7 @@ pool:
   vmImage: 'ubuntu-latest'
 
 jobs:
-- job: 'UserTestInline'
-  timeoutInMinutes: 360
+- job: ListRepos
   steps:
   - task: NodeTool@0
     inputs:
@@ -46,6 +45,32 @@ jobs:
   - script: |
       npm ci
       npm run build
-      node dist/userErrors ${{ parameters.POST_RESULT }} ${{ parameters.OLD_TS_REPO_URL }} ${{ parameters.OLD_HEAD_REF }} ${{ parameters.REQUESTING_USER }} ${{ parameters.SOURCE_ISSUE }} ${{ parameters.STATUS_COMMENT }} ${{ parameters.TOP_REPOS }} ${{ parameters.DIAGNOSTIC_OUTPUT }}
+      mkdir artifacts
+  - script: node dist/listTopRepos TypeScript 100 0 artifacts/repos.json
+    condition: eq('${{ parameters.TOP_REPOS }}', 'true')
+    env:
+      GITHUB_PAT: $(GITHUB_PAT)
+    displayName: 'List top TS repos'
+  - script: node dist/listUserTestRepos ./userTests artifacts/repos.json
+    condition: ne('${{ parameters.TOP_REPOS }}', 'true')
+    displayName: 'List user test repos'
+  - publish: artifacts
+    artifact: RepoList
+- job: UserTestInline
+  dependsOn: ListRepos
+  timeoutInMinutes: 360
+  steps:
+  - download: current
+    artifact: RepoList
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '16.x'
+    displayName: 'Install Node.js'
+  - script: |
+      npm ci
+      npm run build
+      npm install -g pnpm
+      node dist/userErrors ${{ parameters.POST_RESULT }} ${{ parameters.OLD_TS_REPO_URL }} ${{ parameters.OLD_HEAD_REF }} ${{ parameters.REQUESTING_USER }} ${{ parameters.SOURCE_ISSUE }} ${{ parameters.STATUS_COMMENT }} '$(Pipeline.Workspace)/RepoList/repos.json' ${{ parameters.DIAGNOSTIC_OUTPUT }}
+    displayName: 'Run user tests'
     env:
       GITHUB_PAT: $(GITHUB_PAT)

--- a/azure-pipelines-userTests.yml
+++ b/azure-pipelines-userTests.yml
@@ -28,6 +28,15 @@ parameters:
   - name: COMMENT_NUMBER
     displayName: Typescript-bot comment ID indicating that the run started
     type: number
+  - name: MACHINE_COUNT
+    displayName: Machine Count
+    type: number
+    default: 4
+    values:
+    - 1
+    - 2
+    - 4
+    - 8
 
 pr: none
 trigger: none
@@ -58,7 +67,10 @@ jobs:
     artifact: RepoList
 - job: DetectNewErrors
   dependsOn: ListRepos
+  continueOnError: true
   timeoutInMinutes: 360
+  strategy:
+    parallel: ${{ parameters.MACHINE_COUNT }}
   steps:
   - download: current
     artifact: RepoList
@@ -71,17 +83,16 @@ jobs:
       npm run build
       npm install -g pnpm
       mkdir artifacts
-      node dist/userErrors ${{ parameters.OLD_TS_REPO_URL }} ${{ parameters.OLD_HEAD_REF }} ${{ parameters.PR_NUMBER }} '$(Pipeline.Workspace)/RepoList/repos.json' './artifacts' ${{ parameters.DIAGNOSTIC_OUTPUT }}
+      node dist/userErrors ${{ parameters.OLD_TS_REPO_URL }} ${{ parameters.OLD_HEAD_REF }} ${{ parameters.PR_NUMBER }} '$(Pipeline.Workspace)/RepoList/repos.json' $(System.TotalJobsInPhase) $(System.JobPositionInPhase) './artifacts' ${{ parameters.DIAGNOSTIC_OUTPUT }}
     displayName: 'Run user tests'
     env:
       GITHUB_PAT: $(GITHUB_PAT)
   - publish: artifacts
-    artifact: RepoResults
+    artifact: 'RepoResults$(System.JobPositionInPhase)'
 - job: ReportNewErrors
   dependsOn: DetectNewErrors
   steps:
   - download: current
-    artifact: RepoResults
   - task: NodeTool@0
     inputs:
       versionSpec: '16.x'

--- a/azure-pipelines-userTests.yml
+++ b/azure-pipelines-userTests.yml
@@ -19,13 +19,13 @@ parameters:
     displayName: Old head reference
     type: string
     default: main
-  - name: REQUESTING_USER
-    displayName: User name that requested the run
+  - name: USER_TO_TAG
+    displayName: User to tag when the results are ready
     type: string
-  - name: SOURCE_ISSUE
+  - name: PR_NUMBER
     displayName: PR ID in github
     type: number
-  - name: STATUS_COMMENT
+  - name: COMMENT_NUMBER
     displayName: Typescript-bot comment ID indicating that the run started
     type: number
 
@@ -56,7 +56,7 @@ jobs:
     displayName: 'List user test repos'
   - publish: artifacts
     artifact: RepoList
-- job: UserTestInline
+- job: DetectNewErrors
   dependsOn: ListRepos
   timeoutInMinutes: 360
   steps:
@@ -70,7 +70,26 @@ jobs:
       npm ci
       npm run build
       npm install -g pnpm
-      node dist/userErrors ${{ parameters.POST_RESULT }} ${{ parameters.OLD_TS_REPO_URL }} ${{ parameters.OLD_HEAD_REF }} ${{ parameters.REQUESTING_USER }} ${{ parameters.SOURCE_ISSUE }} ${{ parameters.STATUS_COMMENT }} '$(Pipeline.Workspace)/RepoList/repos.json' ${{ parameters.DIAGNOSTIC_OUTPUT }}
+      mkdir artifacts
+      node dist/userErrors ${{ parameters.OLD_TS_REPO_URL }} ${{ parameters.OLD_HEAD_REF }} ${{ parameters.PR_NUMBER }} '$(Pipeline.Workspace)/RepoList/repos.json' './artifacts' ${{ parameters.DIAGNOSTIC_OUTPUT }}
     displayName: 'Run user tests'
+    env:
+      GITHUB_PAT: $(GITHUB_PAT)
+  - publish: artifacts
+    artifact: RepoResults
+- job: ReportNewErrors
+  dependsOn: DetectNewErrors
+  steps:
+  - download: current
+    artifact: RepoResults
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '16.x'
+    displayName: 'Install Node.js'
+  - script: |
+      npm ci
+      npm run build
+      node dist/updateGhComment ${{ parameters.USER_TO_TAG }} ${{ parameters.PR_NUMBER }} ${{ parameters.COMMENT_NUMBER }} '$(Pipeline.Workspace)' ${{ parameters.POST_RESULT }}
+    displayName: 'Update PR comment with new errors'
     env:
       GITHUB_PAT: $(GITHUB_PAT)

--- a/src/createGhIssue.ts
+++ b/src/createGhIssue.ts
@@ -1,0 +1,81 @@
+import fs = require("fs");
+import path = require("path");
+import { Metadata, metadataFileName, RepoStatus, resultFileNameSuffix, StatusCounts } from "./main";
+import git = require("./gitUtils");
+import pu = require("./packageUtils");
+
+const { argv } = process;
+
+if (argv.length !== 6) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <repo_count> <repo_start_index> <result_dir_path> <post_result>`);
+    process.exit(-1);
+}
+
+const [,, repoCount, repoStartIndex, resultDirPath, post] = argv;
+const postResult = post.toLowerCase() === "true";
+
+const metadataFilePaths = pu.glob(resultDirPath, `**/${metadataFileName}`);
+
+let analyzedCount = 0;
+let totalCount = 0;
+const statusCounts: StatusCounts = {};
+
+let newTscResolvedVersion: string | undefined;
+let oldTscResolvedVersion: string | undefined;
+
+for (const path of metadataFilePaths) {
+    const metadata: Metadata = JSON.parse(fs.readFileSync(path, { encoding: "utf-8" }));
+
+    newTscResolvedVersion ??= metadata.newTscResolvedVersion;
+    oldTscResolvedVersion ??= metadata.oldTscResolvedVersion;
+
+    for (const s in metadata.statusCounts) {
+        const status = s as RepoStatus;
+        const count = metadata.statusCounts[status]!;
+        statusCounts[status] = (statusCounts[status] ?? 0) + count;
+        totalCount += count;
+        switch (status) {
+            case "NewBuildSucceeded":
+            case "NewBuildFailed":
+            case "NewBuildHadErrors":
+                analyzedCount += count;
+                break;
+        }
+    }
+}
+
+const title = `[NewErrors] ${newTscResolvedVersion} vs ${oldTscResolvedVersion}`;
+const header = `The following errors were reported by ${newTscResolvedVersion}, but not by ${oldTscResolvedVersion}
+[Pipeline that generated this bug](https://typescript.visualstudio.com/TypeScript/_build?definitionId=48)
+[File that generated the pipeline](https://github.com/microsoft/typescript-error-deltas/blob/main/azure-pipelines-gitTests.yml)
+
+This run considered ${repoCount} popular TS repos from GH (after skipping the top ${repoStartIndex}).
+
+<details>
+<summary>Successfully analyzed ${analyzedCount} of ${totalCount} visited repos</summary>
+
+| Outcome | Count |
+|---------|-------|
+${Object.keys(statusCounts).sort().map(status => `| ${status} | ${statusCounts[status as RepoStatus]} |\n`).join("")}
+</details>
+
+
+`;
+
+const resultPaths = pu.glob(resultDirPath, `**/*.${resultFileNameSuffix}`).sort();
+const outputs = resultPaths.map(p => fs.readFileSync(p, { encoding: "utf-8" }));
+
+
+// GH caps the maximum body length, so paginate if necessary
+const bodyChunks: string[] = [];
+let chunk = header;
+for (const output of outputs) {
+    if (chunk.length + output.length > 65536) {
+        bodyChunks.push(chunk);
+        chunk = "";
+    }
+    chunk += output;
+}
+bodyChunks.push(chunk);
+
+git.createIssue(postResult, title, bodyChunks, /*sawNewErrors*/ !!outputs.length);

--- a/src/gitErrors.ts
+++ b/src/gitErrors.ts
@@ -3,18 +3,20 @@ import { mainAsync, reportError } from "./main";
 
 const { argv } = process;
 
-if (argv.length !== 7) {
-    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <old_tsc_version> <new_tsc_version> <repo_list_path> <result_dir_path> <diagnostic_output>`);
+if (argv.length !== 9) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <old_tsc_version> <new_tsc_version> <repo_list_path> <worker_count> <worker_number> <result_dir_path> <diagnostic_output>`);
     process.exit(-1);
 }
 
-const [,, oldTscVersion, newTscVersion, repoListPath, resultDirPath, diagnosticOutput] = argv;
+const [,, oldTscVersion, newTscVersion, repoListPath, workerCount, workerNumber, resultDirPath, diagnosticOutput] = argv;
 
 mainAsync({
     testType: "git",
     tmpfs: true,
     diagnosticOutput: diagnosticOutput.toLowerCase() === "true",
     repoListPath,
+    workerCount: +workerCount,
+    workerNumber: +workerNumber,
     oldTscVersion,
     newTscVersion,
     resultDirPath,

--- a/src/gitErrors.ts
+++ b/src/gitErrors.ts
@@ -3,20 +3,19 @@ import { mainAsync, reportError } from "./main";
 
 const { argv } = process;
 
-if (argv.length !== 8) {
-    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <post_result> <repo_count> <repo_start_index> <old_tsc_version> <new_tsc_version> <diagnostic_output>`);
+if (argv.length !== 7) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <post_result> <old_tsc_version> <new_tsc_version> <repo_list_path> <diagnostic_output>`);
     process.exit(-1);
 }
 
-const [,, postResultStr, repoCountStr, repoStartIndexStr, oldTscVersion, newTscVersion, diagnosticOutput] = argv;
+const [,, postResultStr, oldTscVersion, newTscVersion, repoListPath, diagnosticOutput] = argv;
 
 mainAsync({
     testType: "git",
     postResult: postResultStr.toLowerCase() === "true", // Only accept true.
     tmpfs: true,
     diagnosticOutput: diagnosticOutput.toLowerCase() === "true",
-    repoCount: +repoCountStr,
-    repoStartIndex: +repoStartIndexStr,
+    repoListPath,
     oldTscVersion,
     newTscVersion,
 }).catch(err => {

--- a/src/gitErrors.ts
+++ b/src/gitErrors.ts
@@ -4,20 +4,20 @@ import { mainAsync, reportError } from "./main";
 const { argv } = process;
 
 if (argv.length !== 7) {
-    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <post_result> <old_tsc_version> <new_tsc_version> <repo_list_path> <diagnostic_output>`);
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <old_tsc_version> <new_tsc_version> <repo_list_path> <result_dir_path> <diagnostic_output>`);
     process.exit(-1);
 }
 
-const [,, postResultStr, oldTscVersion, newTscVersion, repoListPath, diagnosticOutput] = argv;
+const [,, oldTscVersion, newTscVersion, repoListPath, resultDirPath, diagnosticOutput] = argv;
 
 mainAsync({
     testType: "git",
-    postResult: postResultStr.toLowerCase() === "true", // Only accept true.
     tmpfs: true,
     diagnosticOutput: diagnosticOutput.toLowerCase() === "true",
     repoListPath,
     oldTscVersion,
     newTscVersion,
+    resultDirPath,
 }).catch(err => {
     reportError(err, "Unhandled exception");
     process.exit(1);

--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -149,10 +149,10 @@ export async function createIssue(postResult: boolean, title: string, bodyChunks
     }
 }
 
-export async function createComment(sourceIssue: number, statusComment: number, postResult: boolean, body: string): Promise<UserResult | undefined> {
+export async function createComment(prNumber: number, statusComment: number, postResult: boolean, body: string): Promise<UserResult | undefined> {
     const newComment = {
         ...repoProperties,
-        issue_number: sourceIssue,
+        issue_number: prNumber,
         body,
     };
 

--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -20,7 +20,7 @@ const repoProperties = {
     repo: "typescript",
 };
 
-export async function getPopularTypeScriptRepos(count = 100, repoStartIndex = 0, skipRepos?: string[], cachePath?: string): Promise<readonly Repo[]> {
+export async function getPopularRepos(language = "TypeScript", count = 100, repoStartIndex = 0, skipRepos?: string[], cachePath?: string): Promise<readonly Repo[]> {
     const cacheEncoding = { encoding: "utf-8" } as const;
 
     if (cachePath && await utils.exists(cachePath)) {
@@ -39,7 +39,7 @@ export async function getPopularTypeScriptRepos(count = 100, repoStartIndex = 0,
     let repos: Repo[] = [];
     for (let page = 1; repos.length < count; page++) {
         const response = await kit.search.repos({
-            q: "language:TypeScript+stars:>100 archived:no",
+            q: `language:${language}+stars:>100 archived:no`,
             sort: "stars",
             order: "desc",
             per_page: perPage,

--- a/src/listTopRepos.ts
+++ b/src/listTopRepos.ts
@@ -1,0 +1,45 @@
+import fs = require("fs");
+import path = require("path");
+import { getPopularRepos } from "./gitUtils";
+import { reportError } from "./main";
+
+const { argv } = process;
+
+if (argv.length !== 6) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <language> <repo_count> <repo_start_index> <output_path>`);
+    process.exit(-1);
+}
+
+const language = argv[2];
+const repoCount = +argv[3];
+const repoStartIndex = +argv[4];
+const outputPath = argv[5];
+
+// If you think we need coverage of one of these, consider adding a user test with custom build steps
+const skipRepos = [
+    "https://github.com/microsoft/TypeScript", // Test files expected to have errors
+    "https://github.com/DefinitelyTyped/DefinitelyTyped", // Test files expected to have errors
+    "https://github.com/storybookjs/storybook", // Too big to fit on VM
+    "https://github.com/microsoft/frontend-bootcamp", // Can't be built twice in a row
+    "https://github.com/BabylonJS/Babylon.js", // Runs out of space during compile
+    "https://github.com/eclipse-theia/theia", // Probably same
+    "https://github.com/wbkd/react-flow", // Probably same
+    "https://github.com/remix-run/remix", // Too big to fit on VM
+    "https://github.com/NervJS/taro", // Too big to fit on VM
+    "https://github.com/TanStack/table", // Too big to fit on VM
+    "https://github.com/doczjs/docz", // Too big to fit on VM
+    "https://github.com/NativeScript/NativeScript", // Uses NX package manager
+    "https://github.com/wulkano/Kap", // Incompatible with Linux
+    "https://github.com/lit/lit", // Depends on non-public package
+    "https://github.com/coder/code-server", // Takes ~15 minutes and overlaps heavily with vscode
+];
+
+async function mainAsync() {
+    const repos = await getPopularRepos(language, repoCount, repoStartIndex, skipRepos);
+    await fs.promises.writeFile(outputPath, JSON.stringify(repos), { encoding: "utf-8" });
+}
+
+mainAsync().catch(err => {
+    reportError(err, "Unhandled exception");
+    process.exit(1);
+});

--- a/src/listUserTestRepos.ts
+++ b/src/listUserTestRepos.ts
@@ -1,0 +1,23 @@
+import fs = require("fs");
+import path = require("path");
+import { reportError } from "./main";
+import { getUserTestsRepos } from "./userTestUtils";
+
+const { argv } = process;
+
+if (argv.length !== 4) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <user_tests_dir> <output_path>`);
+    process.exit(-1);
+}
+
+const userTestsDir = argv[2];
+const outputPath = argv[3];
+
+try {
+    const repos = getUserTestsRepos(userTestsDir);
+    fs.writeFileSync(outputPath, JSON.stringify(repos), { encoding: "utf-8" });
+}
+catch (err) {
+    reportError(err, "Unhandled exception");
+    process.exit(1);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -313,7 +313,7 @@ export async function mainAsync(params: GitParams | UserParams): Promise<GitResu
     const userTestsDir = path.join(processCwd, "userTests");
 
     const repos = testType === "git" || params.topRepos
-        ? await git.getPopularTypeScriptRepos(params.repoCount, params.repoStartIndex, skipRepos)
+        ? await git.getPopularRepos("TypeScript", params.repoCount, params.repoStartIndex, skipRepos)
         : testType === "user"
             ? ut.getUserTestsRepos(userTestsDir)
             : undefined;

--- a/src/packageUtils.ts
+++ b/src/packageUtils.ts
@@ -15,7 +15,7 @@ interface Package {
 /**
  * `glob`, but ignoring node_modules and symlinks, and returning absolute paths.
  */
-export function glob(cwd: string, pattern: string): readonly string[] {
+export function glob(cwd: string, pattern: string): string[] {
     return globCps.sync(pattern, { cwd, absolute: true, ignore: "**/node_modules/**", follow: false })
 }
 

--- a/src/updateGhComment.ts
+++ b/src/updateGhComment.ts
@@ -1,0 +1,28 @@
+import fs = require("fs");
+import path = require("path");
+import { Metadata, metadataFileName, resultFileNameSuffix } from "./main";
+import git = require("./gitUtils");
+import pu = require("./packageUtils");
+
+const { argv } = process;
+
+if (argv.length !== 7) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <user_to_tag> <pr_number> <comment_number> <result_dir_path> <post_result>`);
+    process.exit(-1);
+}
+
+const [, , userToTag, prNumber, commentNumber, resultDirPath, post] = argv;
+const postResult = post.toLowerCase() === "true";
+
+const metadataFilePaths = pu.glob(resultDirPath, `**/${metadataFileName}`);
+const { newTscResolvedVersion, oldTscResolvedVersion }: Metadata = JSON.parse(fs.readFileSync(metadataFilePaths[0], { encoding: "utf-8" }));
+
+const resultPaths = pu.glob(resultDirPath, `**/*.${resultFileNameSuffix}`).sort();
+const outputs = resultPaths.map(p => fs.readFileSync(p, { encoding: "utf-8" }));
+
+// TODO: this should probably be paginated
+const summary = outputs.join("");
+const body = summary
+    ? `@${userToTag}\nThe results of the user tests run you requested are in!\n<details><summary> Here they are:</summary><p>\n<b>Comparison Report - ${oldTscResolvedVersion}..${newTscResolvedVersion}</b>\n\n${summary}</p></details>`
+    : `@${userToTag}\nGreat news! no new errors were found between ${oldTscResolvedVersion}..${newTscResolvedVersion}`;
+git.createComment(+prNumber, +commentNumber, postResult, body);

--- a/src/userErrors.ts
+++ b/src/userErrors.ts
@@ -17,6 +17,8 @@ mainAsync({
     repoListPath: argv[5],
     resultDirPath: argv[6],
     diagnosticOutput: argv[7].toLowerCase() === "true",
+    workerCount: 1, // TODO (acasey)
+    workerNumber: 1, // TODO (acasey)
 }).catch(err => {
     reportError(err, "Unhandled exception");
     process.exit(1);

--- a/src/userErrors.ts
+++ b/src/userErrors.ts
@@ -3,22 +3,20 @@ import { mainAsync, reportError } from "./main";
 
 const { argv } = process;
 
-if (argv.length !== 10) {
-    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <post_result> <old_typescript_repo_url> <old_head_ref> <requesting_user> <source_issue> <status_comment> <repo_list_path> <diagnostic_output>`);
+if (argv.length !== 8) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <old_typescript_repo_url> <old_head_ref> <pr_number> <repo_list_path> <result_dir_path> <diagnostic_output>`);
     process.exit(-1);
 }
 
 mainAsync({
     testType: "user",
-    postResult: argv[2].toLowerCase() === "true", // Only accept true.
     tmpfs: true,
-    oldTypescriptRepoUrl: argv[3],
-    oldHeadRef: argv[4],
-    requestingUser: argv[5],
-    sourceIssue: +argv[6], // Github's pr ID number.
-    statusComment: +argv[7],
-    repoListPath: argv[8],
-    diagnosticOutput: argv[9].toLowerCase() === "true",
+    oldTypescriptRepoUrl: argv[2],
+    oldHeadRef: argv[3],
+    prNumber: +argv[4],
+    repoListPath: argv[5],
+    resultDirPath: argv[6],
+    diagnosticOutput: argv[7].toLowerCase() === "true",
 }).catch(err => {
     reportError(err, "Unhandled exception");
     process.exit(1);

--- a/src/userErrors.ts
+++ b/src/userErrors.ts
@@ -3,8 +3,8 @@ import { mainAsync, reportError } from "./main";
 
 const { argv } = process;
 
-if (argv.length !== 8) {
-    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <old_typescript_repo_url> <old_head_ref> <pr_number> <repo_list_path> <result_dir_path> <diagnostic_output>`);
+if (argv.length !== 10) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <old_typescript_repo_url> <old_head_ref> <pr_number> <repo_list_path> <worker_count> <worker_number> <result_dir_path> <diagnostic_output>`);
     process.exit(-1);
 }
 
@@ -15,10 +15,10 @@ mainAsync({
     oldHeadRef: argv[3],
     prNumber: +argv[4],
     repoListPath: argv[5],
-    resultDirPath: argv[6],
-    diagnosticOutput: argv[7].toLowerCase() === "true",
-    workerCount: 1, // TODO (acasey)
-    workerNumber: 1, // TODO (acasey)
+    workerCount: +argv[6],
+    workerNumber: +argv[7],
+    resultDirPath: argv[8],
+    diagnosticOutput: argv[9].toLowerCase() === "true",
 }).catch(err => {
     reportError(err, "Unhandled exception");
     process.exit(1);

--- a/src/userErrors.ts
+++ b/src/userErrors.ts
@@ -4,7 +4,7 @@ import { mainAsync, reportError } from "./main";
 const { argv } = process;
 
 if (argv.length !== 10) {
-    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <post_result> <old_typescript_repo_url> <old_head_ref> <requesting_user> <source_issue> <status_comment> <top_repos> <diagnostic_output>`);
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <post_result> <old_typescript_repo_url> <old_head_ref> <requesting_user> <source_issue> <status_comment> <repo_list_path> <diagnostic_output>`);
     process.exit(-1);
 }
 
@@ -17,7 +17,7 @@ mainAsync({
     requestingUser: argv[5],
     sourceIssue: +argv[6], // Github's pr ID number.
     statusComment: +argv[7],
-    topRepos: argv[8].toLowerCase() === "true", // Only accept true.
+    repoListPath: argv[8],
     diagnosticOutput: argv[9].toLowerCase() === "true",
 }).catch(err => {
     reportError(err, "Unhandled exception");

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -6,34 +6,6 @@ import { UserResult } from '../src/gitUtils'
 import path = require("path")
 describe("main", () => {
     jest.setTimeout(10 * 60 * 1000)
-    xit("user tests run from scratch", async () => {
-        const options: UserParams = {
-            postResult: false, // for testing
-            tmpfs: false,
-            testType: "user",
-            oldTypescriptRepoUrl: 'https://github.com/microsoft/typescript',
-            oldHeadRef: 'main', // TODO: only branch names seem to work here, not all refs
-            requestingUser: 'sandersn',
-            sourceIssue: 44585,
-            statusComment: 990374547,
-            repoListPath: "ENOENT", // TODO: write Repo for TypeScript-Node-Starter to a json file
-        }
-        const result = await mainAsync(options)
-        expect(result).toBeDefined()
-        const ur = result as UserResult;
-        expect(ur.kind).toEqual('user')
-        expect(ur.owner).toEqual('microsoft')
-        expect(ur.repo).toEqual('typescript')
-        expect(ur.issue_number).toEqual(44585)
-        expect(ur.body.startsWith(`@sandersn
-The results of the user tests run you requested are in!
-<details><summary> Here they are:</summary><p>
-<b>Comparison Report - main..refs/pull/44585/merge</b>
-
-# [TypeScript-Node-Starter](https://github.com/Microsoft/TypeScript-Node-Starter.git)
-### /mnt/ts_downloads/TypeScript-Node-Starter/tsconfig.json
-- \`error TS2496: The 'arguments' object cannot be referenced in an arrow function in ES3 and ES5. Consider using a standard function expression.\``)).toBeTruthy()
-    })
     xit("build-only correctly caches", async () => {
         const { status, summary } = await getRepoResult(
             {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -10,14 +10,13 @@ describe("main", () => {
         const options: UserParams = {
             postResult: false, // for testing
             tmpfs: false,
-            repoCount: 1, // also for testing
             testType: "user",
             oldTypescriptRepoUrl: 'https://github.com/microsoft/typescript',
             oldHeadRef: 'main', // TODO: only branch names seem to work here, not all refs
             requestingUser: 'sandersn',
             sourceIssue: 44585,
             statusComment: 990374547,
-            topRepos: false,
+            repoListPath: "ENOENT", // TODO: write Repo for TypeScript-Node-Starter to a json file
         }
         const result = await mainAsync(options)
         expect(result).toBeDefined()

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,5 +1,5 @@
 /// <reference types="jest" />
-import { mainAsync, getRepoStatus, UserParams, downloadTypescriptRepoAsync } from '../src/main'
+import { mainAsync, getRepoResult, UserParams, downloadTypescriptRepoAsync } from '../src/main'
 import { execSync } from "child_process"
 import { existsSync, mkdirSync } from "fs"
 import { UserResult } from '../src/gitUtils'
@@ -35,8 +35,7 @@ The results of the user tests run you requested are in!
 - \`error TS2496: The 'arguments' object cannot be referenced in an arrow function in ES3 and ES5. Consider using a standard function expression.\``)).toBeTruthy()
     })
     xit("build-only correctly caches", async () => {
-        const outputs: string[] = []
-        const status = await getRepoStatus(
+        const { status, summary } = await getRepoResult(
             {
                 name: "TypeScript-Node-Starter",
                 url: "https://github.com/Microsoft/TypeScript-Node-Starter.git"
@@ -47,11 +46,11 @@ The results of the user tests run you requested are in!
             /*ignoreOldTscFailures*/ true, // as in a user test
             "./ts_downloads",
             /*isDownloadDirOnTmpFs*/ false,
-            /*diagnosticOutput*/ false,
-            outputs)
+            /*diagnosticOutput*/ false)
         expect(status).toEqual("NewBuildHadErrors")
-        expect(outputs.join("").startsWith(`# [TypeScript-Node-Starter](https://github.com/Microsoft/TypeScript-Node-Starter.git)`)).toBeTruthy()
-        expect(outputs.join("").includes("- \`error TS2496: The 'arguments' object cannot be referenced in an arrow function in ES3 and ES5. Consider using a standard function expression.\`")).toBeTruthy()
+        expect(summary).toBeDefined()
+        expect(summary!.startsWith(`# [TypeScript-Node-Starter](https://github.com/Microsoft/TypeScript-Node-Starter.git)`)).toBeTruthy()
+        expect(summary!.includes("- \`error TS2496: The 'arguments' object cannot be referenced in an arrow function in ES3 and ES5. Consider using a standard function expression.\`")).toBeTruthy()
     })
     it("downloads from a branch", async () => {
         if (!existsSync("./testDownloads/main")) {


### PR DESCRIPTION
Phase 1: Determine list of repos to process
Phase 2: Partition the workers between a number of workers (default 4)
Phase 3: Collect results from all repos and summarize in a GH issue or comment

Pipeline artifacts are used to communicate between the phases.  Phase 1 produces a repro list and Phase 2 produces a markdown fragment file for each repo (plus a bonus file with some metadata for the report).

Note that this uses partitioning, rather than work-stealing, so it's not as efficient as it could be.