### PR TITLE
Make User Test output more detailed

### DIFF
--- a/azure-pipelines-gitTests.yml
+++ b/azure-pipelines-gitTests.yml
@@ -99,7 +99,7 @@ jobs:
   - script: |
       npm ci
       npm run build
-      node dist/createGhIssue ${{ parameters.REPO_COUNT }} ${{ parameters.REPO_START_INDEX }} '$(Pipeline.Workspace)' ${{ parameters.POST_RESULT }}
+      node dist/createGhIssue ${{ parameters.REPO_COUNT }} ${{ parameters.REPO_START_INDEX }} '$(Pipeline.Workspace)' '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)' ${{ parameters.POST_RESULT }}
     displayName: 'Create issue from new errors'
     env:
       GITHUB_PAT: $(GITHUB_PAT)

--- a/azure-pipelines-userTests.yml
+++ b/azure-pipelines-userTests.yml
@@ -100,7 +100,7 @@ jobs:
   - script: |
       npm ci
       npm run build
-      node dist/updateGhComment ${{ parameters.USER_TO_TAG }} ${{ parameters.PR_NUMBER }} ${{ parameters.COMMENT_NUMBER }} '$(Pipeline.Workspace)' ${{ parameters.POST_RESULT }}
+      node dist/updateGhComment ${{ parameters.USER_TO_TAG }} ${{ parameters.PR_NUMBER }} ${{ parameters.COMMENT_NUMBER }} '$(Pipeline.Workspace)' '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)' ${{ parameters.POST_RESULT }}
     displayName: 'Update PR comment with new errors'
     env:
       GITHUB_PAT: $(GITHUB_PAT)

--- a/src/createGhIssue.ts
+++ b/src/createGhIssue.ts
@@ -6,12 +6,12 @@ import pu = require("./packageUtils");
 
 const { argv } = process;
 
-if (argv.length !== 6) {
-    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <repo_count> <repo_start_index> <result_dir_path> <post_result>`);
+if (argv.length !== 7) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <repo_count> <repo_start_index> <result_dir_path> <log_uri> <post_result>`);
     process.exit(-1);
 }
 
-const [,, repoCount, repoStartIndex, resultDirPath, post] = argv;
+const [,, repoCount, repoStartIndex, resultDirPath, logUri, post] = argv;
 const postResult = post.toLowerCase() === "true";
 
 const metadataFilePaths = pu.glob(resultDirPath, `**/${metadataFileName}`);
@@ -47,6 +47,7 @@ for (const path of metadataFilePaths) {
 const title = `[NewErrors] ${newTscResolvedVersion} vs ${oldTscResolvedVersion}`;
 const header = `The following errors were reported by ${newTscResolvedVersion}, but not by ${oldTscResolvedVersion}
 [Pipeline that generated this bug](https://typescript.visualstudio.com/TypeScript/_build?definitionId=48)
+[Logs for the pipeline run](${logUri})
 [File that generated the pipeline](https://github.com/microsoft/typescript-error-deltas/blob/main/azure-pipelines-gitTests.yml)
 
 This run considered ${repoCount} popular TS repos from GH (after skipping the top ${repoStartIndex}).

--- a/src/createGhIssue.ts
+++ b/src/createGhIssue.ts
@@ -35,9 +35,9 @@ for (const path of metadataFilePaths) {
         statusCounts[status] = (statusCounts[status] ?? 0) + count;
         totalCount += count;
         switch (status) {
-            case "NewBuildSucceeded":
-            case "NewBuildFailed":
-            case "NewBuildHadErrors":
+            case "Detected no interesting changes":
+            case "Detected interesting changes":
+            case "Detected project-graph error":
                 analyzedCount += count;
                 break;
         }

--- a/src/updateGhComment.ts
+++ b/src/updateGhComment.ts
@@ -6,12 +6,12 @@ import pu = require("./packageUtils");
 
 const { argv } = process;
 
-if (argv.length !== 7) {
-    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <user_to_tag> <pr_number> <comment_number> <result_dir_path> <post_result>`);
+if (argv.length !== 8) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <user_to_tag> <pr_number> <comment_number> <result_dir_path> <log_uri> <post_result>`);
     process.exit(-1);
 }
 
-const [, , userToTag, prNumber, commentNumber, resultDirPath, post] = argv;
+const [, , userToTag, prNumber, commentNumber, resultDirPath, logUri, post] = argv;
 const postResult = post.toLowerCase() === "true";
 
 const metadataFilePaths = pu.glob(resultDirPath, `**/${metadataFileName}`);
@@ -79,5 +79,7 @@ ${outputs.join("")}
 </details>
 `;
 }
+
+body += `\n\n[Run logs](${logUri})`;
 
 git.createComment(+prNumber, +commentNumber, postResult, body);

--- a/src/updateGhComment.ts
+++ b/src/updateGhComment.ts
@@ -65,7 +65,7 @@ const resultPaths = pu.glob(resultDirPath, `**/*.${resultFileNameSuffix}`).sort(
 const outputs = resultPaths.map(p => fs.readFileSync(p, { encoding: "utf-8" }));
 
 // TODO: this should probably be paginated
-let body = `@${userToTag} Here are the results of running the user test suite comparing ${oldTscResolvedVersion} and ${newTscResolvedVersion}
+let body = `@${userToTag} Here are the results of running the user test suite comparing \`${oldTscResolvedVersion}\` and \`${newTscResolvedVersion}\`:
 
 ${summary}`;
 


### PR DESCRIPTION
Use clearer repo statuses, drop messages that don't apply to user test runs, and list errors that are no longer reported.