### PR TITLE
Refine output of top100 tests

### DIFF
--- a/azure-pipelines-userTests.yml
+++ b/azure-pipelines-userTests.yml
@@ -67,7 +67,6 @@ jobs:
     artifact: RepoList
 - job: DetectNewErrors
   dependsOn: ListRepos
-  continueOnError: false
   timeoutInMinutes: 360
   strategy:
     parallel: ${{ parameters.MACHINE_COUNT }}
@@ -83,7 +82,7 @@ jobs:
       npm run build
       npm install -g pnpm
       mkdir artifacts
-      node dist/userErrors ${{ parameters.OLD_TS_REPO_URL }} ${{ parameters.OLD_HEAD_REF }} ${{ parameters.SOURCE_ISSUE }} '$(Pipeline.Workspace)/RepoList/repos.json' $(System.TotalJobsInPhase) $(System.JobPositionInPhase) './artifacts' ${{ parameters.DIAGNOSTIC_OUTPUT }}
+      node dist/userErrors ${{ parameters.OLD_TS_REPO_URL }} ${{ parameters.OLD_HEAD_REF }} ${{ parameters.SOURCE_ISSUE }} ${{ parameters.TOP_REPOS }} '$(Pipeline.Workspace)/RepoList/repos.json' $(System.TotalJobsInPhase) $(System.JobPositionInPhase) './artifacts' ${{ parameters.DIAGNOSTIC_OUTPUT }}
     displayName: 'Run user tests'
     env:
       GITHUB_PAT: $(GITHUB_PAT)

--- a/src/createGhIssue.ts
+++ b/src/createGhIssue.ts
@@ -70,7 +70,7 @@ const outputs = resultPaths.map(p => fs.readFileSync(p, { encoding: "utf-8" }));
 const bodyChunks: string[] = [];
 let chunk = header;
 for (const output of outputs) {
-    if (chunk.length + output.length > 65536) {
+    if (chunk.length + output.length > 65535) {
         bodyChunks.push(chunk);
         chunk = "";
     }

--- a/src/gitErrors.ts
+++ b/src/gitErrors.ts
@@ -14,6 +14,7 @@ mainAsync({
     testType: "git",
     tmpfs: true,
     diagnosticOutput: diagnosticOutput.toLowerCase() === "true",
+    buildWithNewWhenOldFails: false,
     repoListPath,
     workerCount: +workerCount,
     workerNumber: +workerNumber,

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,11 @@ interface Params {
      * True to produce more verbose output (e.g. to help diagnose resource exhaustion issues).
      * Default is false to save time and space.
      */
-    diagnosticOutput?: boolean | undefined;
+    diagnosticOutput?: boolean;
+    /**
+     * True to allow errors in the baseline build and report as missing any not reported by the candidate build.
+     */
+    buildWithNewWhenOldFails: boolean;
     /**
      * Path to a JSON file containing an array of Repo objects to be processed.
      */
@@ -373,7 +377,7 @@ export async function mainAsync(params: GitParams | UserParams): Promise<void> {
     for (const repo of repos) {
         console.log(`Starting #${i++} / ${repos.length}: ${repo.url ?? repo.name}`);
 
-        const { status, summary } = await getRepoResult(repo, userTestsDir, oldTscPath, newTscPath, /*buildWithNewWhenOldFails*/ testType === "user", downloadDir, params.tmpfs, !!params.diagnosticOutput);
+        const { status, summary } = await getRepoResult(repo, userTestsDir, oldTscPath, newTscPath, params.buildWithNewWhenOldFails, downloadDir, params.tmpfs, !!params.diagnosticOutput);
         console.log(`Repo ${repo.url ?? repo.name} had status ${status}`);
         statusCounts[status] = (statusCounts[status] ?? 0) + 1;
         if (summary) {

--- a/src/updateGhComment.ts
+++ b/src/updateGhComment.ts
@@ -45,11 +45,11 @@ for (const path of metadataFilePaths) {
 }
 
 let summary: string;
-if (infrastructureFailed) {
-    summary = `Unfortunately, something went wrong, but it probably wasn't caused by your change.`;
-}
-else if (somethingChanged) {
+if (somethingChanged && (isTopReposRun || !infrastructureFailed)) {
     summary = `Something interesting changed - please have a look.`;
+}
+else if (infrastructureFailed && !isTopReposRun) {
+    summary = `Unfortunately, something went wrong, but it probably wasn't caused by your change.`;
 }
 else {
     summary = `Everything looks good!`;

--- a/src/updateGhComment.ts
+++ b/src/updateGhComment.ts
@@ -74,7 +74,7 @@ else {
     const bodyChunks: string[] = [];
     let chunk = header + openDetails;
     for (const output of outputs) {
-        if (chunk.length + output.length + closeDetails.length> 65536) {
+        if (chunk.length + output.length + closeDetails.length > 65535) {
             chunk += closeDetails;
             bodyChunks.push(chunk);
             chunk = `@${userToTag} Here are some more interesting changes from running the ${suiteDescription} suite${openDetails}`;
@@ -83,6 +83,10 @@ else {
     }
     chunk += closeDetails;
     bodyChunks.push(chunk);
+
+    for (const chunk of bodyChunks) {
+        console.log(`Chunk of size ${chunk.length}`);
+    }
 
     git.createComment(+prNumber, +commentNumber, postResult, bodyChunks);
 }

--- a/src/userErrors.ts
+++ b/src/userErrors.ts
@@ -3,8 +3,8 @@ import { mainAsync, reportError } from "./main";
 
 const { argv } = process;
 
-if (argv.length !== 10) {
-    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <old_typescript_repo_url> <old_head_ref> <pr_number> <repo_list_path> <worker_count> <worker_number> <result_dir_path> <diagnostic_output>`);
+if (argv.length !== 11) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <old_typescript_repo_url> <old_head_ref> <pr_number> <is_top_repos> <repo_list_path> <worker_count> <worker_number> <result_dir_path> <diagnostic_output>`);
     process.exit(-1);
 }
 
@@ -14,11 +14,12 @@ mainAsync({
     oldTypescriptRepoUrl: argv[2],
     oldHeadRef: argv[3],
     prNumber: +argv[4],
-    repoListPath: argv[5],
-    workerCount: +argv[6],
-    workerNumber: +argv[7],
-    resultDirPath: argv[8],
-    diagnosticOutput: argv[9].toLowerCase() === "true",
+    buildWithNewWhenOldFails: argv[5].toLowerCase() !== "true",
+    repoListPath: argv[6],
+    workerCount: +argv[7],
+    workerNumber: +argv[8],
+    resultDirPath: argv[9],
+    diagnosticOutput: argv[10].toLowerCase() === "true",
 }).catch(err => {
     reportError(err, "Unhandled exception");
     process.exit(1);


### PR DESCRIPTION
Don't consider projects that didn't build with the baseline tsc and truncate individual repo output, if necessary.