### PR TITLE
Change working directory of kill-children-of call

### DIFF
--- a/src/utils/execUtils.ts
+++ b/src/utils/execUtils.ts
@@ -58,7 +58,7 @@ export function spawnWithTimeoutAsync(cwd: string, command: string, args: readon
         childProcess.on("close", async (code, signal) => {
             // SIGTERM indicates timeout
             if (signal === "SIGTERM") {
-                await execAsync(path.join(__dirname, "..", "scripts"), `./kill-children-of ${childProcess.pid}`);
+                await execAsync(path.join(__dirname, "..", "..", "scripts"), `./kill-children-of ${childProcess.pid}`);
                 resolve(undefined);
                 return;
             }


### PR DESCRIPTION
It looks like it should be ../../scripts not ../scripts, since it's called from inside utils/execUtils.ts