### PR TITLE
Add a flag for exercise tsserver, rather than tsc

### DIFF
--- a/azure-pipelines-gitTests.yml
+++ b/azure-pipelines-gitTests.yml
@@ -16,11 +16,11 @@ parameters:
     type: number
     default: 0
   - name: OLD_VERSION
-    displayName: Baseline typescript package version
+    displayName: Baseline TypeScript package version
     type: string
     default: latest
   - name: NEW_VERSION
-    displayName: Candidate typescript package version
+    displayName: Candidate TypeScript package version
     type: string
     default: next
   - name: MACHINE_COUNT
@@ -32,6 +32,13 @@ parameters:
     - 2
     - 4
     - 8
+  - name: ENTRYPOINT
+    displayName: TypeScript entrypoint
+    type: string
+    default: tsc
+    values:
+    - tsc
+    - tsserver
 
 schedules:
   - cron: "0 18 * * Sun" # time is in UTC
@@ -81,12 +88,13 @@ jobs:
       npm ci
       npm run build
       npm install -g pnpm
-      mkdir artifacts
-      node dist/checkGithubRepos ${{ parameters.OLD_VERSION }} ${{ parameters.NEW_VERSION }} '$(Pipeline.Workspace)/RepoList/repos.json' $(System.TotalJobsInPhase) $(System.JobPositionInPhase) './artifacts' ${{ parameters.DIAGNOSTIC_OUTPUT }}
-    displayName: 'Run tsc on repos'
+      mkdir 'RepoResults$(System.JobPositionInPhase)'
+      node dist/checkGithubRepos ${{ parameters.ENTRYPOINT }} ${{ parameters.OLD_VERSION }} ${{ parameters.NEW_VERSION }} '$(Pipeline.Workspace)/RepoList/repos.json' $(System.TotalJobsInPhase) $(System.JobPositionInPhase) 'RepoResults$(System.JobPositionInPhase)' ${{ parameters.DIAGNOSTIC_OUTPUT }}
+    displayName: 'Run TypeScript on repos'
+    continueOnError: true
     env:
       GITHUB_PAT: $(GITHUB_PAT)
-  - publish: artifacts
+  - publish: 'RepoResults$(System.JobPositionInPhase)'
     artifact: 'RepoResults$(System.JobPositionInPhase)'
 - job: ReportNewErrors
   dependsOn: DetectNewErrors
@@ -99,7 +107,7 @@ jobs:
   - script: |
       npm ci
       npm run build
-      node dist/postGithubIssue ${{ parameters.REPO_COUNT }} ${{ parameters.REPO_START_INDEX }} '$(Pipeline.Workspace)' '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)' ${{ parameters.POST_RESULT }}
+      node dist/postGithubIssue ${{ parameters.ENTRYPOINT }} ${{ parameters.REPO_COUNT }} ${{ parameters.REPO_START_INDEX }} '$(Pipeline.Workspace)' '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)' '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=artifacts&type=publishedArtifacts' ${{ parameters.POST_RESULT }}
     displayName: 'Create issue from new errors'
     env:
       GITHUB_PAT: $(GITHUB_PAT)

--- a/azure-pipelines-userTests.yml
+++ b/azure-pipelines-userTests.yml
@@ -37,6 +37,13 @@ parameters:
     - 2
     - 4
     - 8
+  - name: ENTRYPOINT
+    displayName: TypeScript entrypoint
+    type: string
+    default: tsc
+    values:
+    - tsc
+    - tsserver
 
 pr: none
 trigger: none
@@ -81,12 +88,12 @@ jobs:
       npm ci
       npm run build
       npm install -g pnpm
-      mkdir artifacts
-      node dist/checkUserTestRepos ${{ parameters.OLD_TS_REPO_URL }} ${{ parameters.OLD_HEAD_REF }} ${{ parameters.SOURCE_ISSUE }} ${{ parameters.TOP_REPOS }} '$(Pipeline.Workspace)/RepoList/repos.json' $(System.TotalJobsInPhase) $(System.JobPositionInPhase) './artifacts' ${{ parameters.DIAGNOSTIC_OUTPUT }}
+      mkdir 'RepoResults$(System.JobPositionInPhase)'
+      node dist/checkUserTestRepos ${{ parameters.ENTRYPOINT }} ${{ parameters.OLD_TS_REPO_URL }} ${{ parameters.OLD_HEAD_REF }} ${{ parameters.SOURCE_ISSUE }} ${{ parameters.TOP_REPOS }} '$(Pipeline.Workspace)/RepoList/repos.json' $(System.TotalJobsInPhase) $(System.JobPositionInPhase) 'RepoResults$(System.JobPositionInPhase)' ${{ parameters.DIAGNOSTIC_OUTPUT }}
     displayName: 'Run user tests'
     env:
       GITHUB_PAT: $(GITHUB_PAT)
-  - publish: artifacts
+  - publish: 'RepoResults$(System.JobPositionInPhase)'
     artifact: 'RepoResults$(System.JobPositionInPhase)'
 - job: ReportNewErrors
   dependsOn: DetectNewErrors
@@ -99,7 +106,7 @@ jobs:
   - script: |
       npm ci
       npm run build
-      node dist/postGithubComments ${{ parameters.REQUESTING_USER }} ${{ parameters.SOURCE_ISSUE }} ${{ parameters.STATUS_COMMENT }} ${{ parameters.TOP_REPOS }} '$(Pipeline.Workspace)' ${{ parameters.POST_RESULT }}
+      node dist/postGithubComments ${{ parameters.REQUESTING_USER }} ${{ parameters.SOURCE_ISSUE }} ${{ parameters.STATUS_COMMENT }} ${{ parameters.TOP_REPOS }} '$(Pipeline.Workspace)' '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=artifacts&type=publishedArtifacts' ${{ parameters.POST_RESULT }}
     displayName: 'Update PR comment with new errors'
     env:
       GITHUB_PAT: $(GITHUB_PAT)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
             "dependencies": {
                 "@octokit/rest": "^16.43.2",
                 "@typescript/github-link": "^0.2.1",
+                "@typescript/server-harness": "^0.2.0",
+                "@typescript/server-replay": "^0.2.5",
                 "glob": "^7.2.3",
                 "json5": "^2.2.1",
                 "simple-git": "^3.10.0"
@@ -1261,6 +1263,23 @@
             "resolved": "https://registry.npmjs.org/@typescript/github-link/-/github-link-0.2.1.tgz",
             "integrity": "sha512-Q5aDnbTuw9ovvVnZ+ZFbLzTGvPLJCQvFd2dsiQ84UfMVZfSAm1EJVwVSTMKOEvTJVI1r/tuV0rRvE2XGBRuqwg=="
         },
+        "node_modules/@typescript/server-harness": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript/server-harness/-/server-harness-0.2.0.tgz",
+            "integrity": "sha512-WbZwpC48MVRQsBFUEvTCisahsEqpvBltSaRuJ0KkSa/e6EuhMW9pE5WpYLZBWiIvI0YhuEYvTol8L/I7hOZFtw=="
+        },
+        "node_modules/@typescript/server-replay": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/@typescript/server-replay/-/server-replay-0.2.5.tgz",
+            "integrity": "sha512-feKfr4KumR6dAmO9tnotwvPCT9oH5fCfijp0Gb9WRlWF0YG8FA3ad7/bphZW3gxr/8ZAB7KzAy8nKbX9kBjQfQ==",
+            "dependencies": {
+                "@typescript/server-harness": "^0.2.0",
+                "yargs": "^16.2.0"
+            },
+            "bin": {
+                "tsreplay": "bin/tsreplay"
+            }
+        },
         "node_modules/abab": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -1341,7 +1360,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -1350,7 +1368,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -1658,7 +1675,6 @@
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
             "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-            "dev": true,
             "dependencies": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
@@ -1685,7 +1701,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -1696,8 +1711,7 @@
         "node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
@@ -1894,8 +1908,7 @@
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "node_modules/end-of-stream": {
             "version": "1.4.4",
@@ -1918,7 +1931,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
             "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -2130,7 +2142,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true,
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
             }
@@ -2341,7 +2352,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3749,7 +3759,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3958,7 +3967,6 @@
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -3972,7 +3980,6 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -4547,7 +4554,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -4614,7 +4620,6 @@
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true,
             "engines": {
                 "node": ">=10"
             }
@@ -4629,7 +4634,6 @@
             "version": "16.2.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
             "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-            "dev": true,
             "dependencies": {
                 "cliui": "^7.0.2",
                 "escalade": "^3.1.1",
@@ -4647,7 +4651,6 @@
             "version": "20.2.9",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
             "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-            "dev": true,
             "engines": {
                 "node": ">=10"
             }
@@ -5701,6 +5704,20 @@
             "resolved": "https://registry.npmjs.org/@typescript/github-link/-/github-link-0.2.1.tgz",
             "integrity": "sha512-Q5aDnbTuw9ovvVnZ+ZFbLzTGvPLJCQvFd2dsiQ84UfMVZfSAm1EJVwVSTMKOEvTJVI1r/tuV0rRvE2XGBRuqwg=="
         },
+        "@typescript/server-harness": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript/server-harness/-/server-harness-0.2.0.tgz",
+            "integrity": "sha512-WbZwpC48MVRQsBFUEvTCisahsEqpvBltSaRuJ0KkSa/e6EuhMW9pE5WpYLZBWiIvI0YhuEYvTol8L/I7hOZFtw=="
+        },
+        "@typescript/server-replay": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/@typescript/server-replay/-/server-replay-0.2.5.tgz",
+            "integrity": "sha512-feKfr4KumR6dAmO9tnotwvPCT9oH5fCfijp0Gb9WRlWF0YG8FA3ad7/bphZW3gxr/8ZAB7KzAy8nKbX9kBjQfQ==",
+            "requires": {
+                "@typescript/server-harness": "^0.2.0",
+                "yargs": "^16.2.0"
+            }
+        },
         "abab": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -5758,14 +5775,12 @@
         "ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
         },
         "ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
             "requires": {
                 "color-convert": "^2.0.1"
             }
@@ -5996,7 +6011,6 @@
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
             "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-            "dev": true,
             "requires": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
@@ -6019,7 +6033,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "requires": {
                 "color-name": "~1.1.4"
             }
@@ -6027,8 +6040,7 @@
         "color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "combined-stream": {
             "version": "1.0.8",
@@ -6185,8 +6197,7 @@
         "emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "end-of-stream": {
             "version": "1.4.4",
@@ -6208,8 +6219,7 @@
         "escalade": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-            "dev": true
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
         },
         "escape-string-regexp": {
             "version": "2.0.0",
@@ -6361,8 +6371,7 @@
         "get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
         },
         "get-package-type": {
             "version": "0.1.0",
@@ -6515,8 +6524,7 @@
         "is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "is-generator-fn": {
             "version": "2.1.0",
@@ -7599,8 +7607,7 @@
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "dev": true
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
         },
         "resolve": {
             "version": "1.22.1",
@@ -7757,7 +7764,6 @@
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
             "requires": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -7768,7 +7774,6 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
             "requires": {
                 "ansi-regex": "^5.0.1"
             }
@@ -8167,7 +8172,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -8213,8 +8217,7 @@
         "y18n": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
         },
         "yallist": {
             "version": "4.0.0",
@@ -8226,7 +8229,6 @@
             "version": "16.2.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
             "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-            "dev": true,
             "requires": {
                 "cliui": "^7.0.2",
                 "escalade": "^3.1.1",
@@ -8240,8 +8242,7 @@
         "yargs-parser": {
             "version": "20.2.9",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-            "dev": true
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "dependencies": {
         "@octokit/rest": "^16.43.2",
         "@typescript/github-link": "^0.2.1",
+        "@typescript/server-harness": "^0.2.0",
+        "@typescript/server-replay": "^0.2.5",
         "glob": "^7.2.3",
         "json5": "^2.2.1",
         "simple-git": "^3.10.0"

--- a/src/checkGithubRepos.ts
+++ b/src/checkGithubRepos.ts
@@ -1,26 +1,27 @@
 import path = require("path");
-import { mainAsync, reportError } from "./main";
+import { mainAsync, reportError, TsEntrypoint } from "./main";
 
 const { argv } = process;
 
-if (argv.length !== 9) {
-    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <old_tsc_version> <new_tsc_version> <repo_list_path> <worker_count> <worker_number> <result_dir_path> <diagnostic_output>`);
+if (argv.length !== 10) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <ts_entrypoint> <old_ts_npm_version> <new_ts_npm_version> <repo_list_path> <worker_count> <worker_number> <result_dir_name> <diagnostic_output>`);
     process.exit(-1);
 }
 
-const [,, oldTscVersion, newTscVersion, repoListPath, workerCount, workerNumber, resultDirPath, diagnosticOutput] = argv;
+const [,, entrypoint, oldTsNpmVersion, newTsNpmVersion, repoListPath, workerCount, workerNumber, resultDirName, diagnosticOutput] = argv;
 
 mainAsync({
-    testType: "git",
+    testType: "github",
     tmpfs: true,
+    entrypoint: entrypoint as TsEntrypoint,
     diagnosticOutput: diagnosticOutput.toLowerCase() === "true",
     buildWithNewWhenOldFails: false,
     repoListPath,
     workerCount: +workerCount,
     workerNumber: +workerNumber,
-    oldTscVersion,
-    newTscVersion,
-    resultDirPath,
+    oldTsNpmVersion,
+    newTsNpmVersion,
+    resultDirName,
 }).catch(err => {
     reportError(err, "Unhandled exception");
     process.exit(1);

--- a/src/checkUserTestRepos.ts
+++ b/src/checkUserTestRepos.ts
@@ -1,25 +1,28 @@
 import path = require("path");
-import { mainAsync, reportError } from "./main";
+import { mainAsync, reportError, TsEntrypoint } from "./main";
 
 const { argv } = process;
 
-if (argv.length !== 11) {
-    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <old_typescript_repo_url> <old_head_ref> <pr_number> <is_top_repos> <repo_list_path> <worker_count> <worker_number> <result_dir_path> <diagnostic_output>`);
+if (argv.length !== 12) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <ts_entrypoint> <old_ts_repo_url> <old_head_ref> <pr_number> <is_top_repos> <repo_list_path> <worker_count> <worker_number> <result_dir_name> <diagnostic_output>`);
     process.exit(-1);
 }
+
+const [,, entrypoint, oldTsRepoUrl, oldHeadRef, prNumber, buildWithNewWhenOldFails, repoListPath, workerCount, workerNumber, resultDirName, diagnosticOutput] = argv;
 
 mainAsync({
     testType: "user",
     tmpfs: true,
-    oldTypescriptRepoUrl: argv[2],
-    oldHeadRef: argv[3],
-    prNumber: +argv[4],
-    buildWithNewWhenOldFails: argv[5].toLowerCase() !== "true",
-    repoListPath: argv[6],
-    workerCount: +argv[7],
-    workerNumber: +argv[8],
-    resultDirPath: argv[9],
-    diagnosticOutput: argv[10].toLowerCase() === "true",
+    entrypoint: entrypoint as TsEntrypoint,
+    oldTsRepoUrl,
+    oldHeadRef,
+    prNumber: +prNumber,
+    buildWithNewWhenOldFails: buildWithNewWhenOldFails.toLowerCase() !== "true",
+    repoListPath,
+    workerCount: +workerCount,
+    workerNumber: +workerNumber,
+    resultDirName,
+    diagnosticOutput: diagnosticOutput.toLowerCase() === "true",
 }).catch(err => {
     reportError(err, "Unhandled exception");
     process.exit(1);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,8 @@
+import exercise = require("./utils/exerciseServerConstants");
 import ge = require("./utils/getTscErrors");
 import pu = require("./utils/packageUtils");
 import git = require("./utils/gitUtils");
-import { execAsync, spawnWithTimeoutAsync } from "./utils/execUtils";
+import { execAsync, SpawnResult, spawnWithTimeoutAsync } from "./utils/execUtils";
 import ip = require("./utils/installPackages");
 import ut = require("./utils/userTestUtils");
 import fs = require("fs");
@@ -35,25 +36,31 @@ interface Params {
      */
     workerNumber: number;
     /**
-     * Path to a directory in which a summary file should be written for each repo to be included in the output
+     * Name of a directory in which a summary file should be written for each repo to be included in the output
      * (i.e. those with interesting failures).
+     * Sneakiness: not a path since referred to in output as component of AzDO artifact name
      */
-    resultDirPath: string;
+    resultDirName: string;
+    /**
+     * Which TypeScript entrypoint (tsc or tsserver) to test.
+     */
+    entrypoint: TsEntrypoint;
 }
 export interface GitParams extends Params {
-    testType: 'git';
-    oldTscVersion: string;
-    newTscVersion: string;
+    testType: "github";
+    oldTsNpmVersion: string;
+    newTsNpmVersion: string;
 }
 export interface UserParams extends Params {
-    testType: 'user';
-    oldTypescriptRepoUrl: string;
+    testType: "user";
+    oldTsRepoUrl: string;
     oldHeadRef: string;
     prNumber: number;
 }
 
+export type TsEntrypoint = "tsc" | "tsserver";
+
 const processCwd = process.cwd();
-const processPid = process.pid;
 const packageTimeout = 10 * 60 * 1000;
 const executionTimeout = 10 * 60 * 1000;
 
@@ -63,6 +70,7 @@ export type RepoStatus =
     | "Package install failed"
     | "Project-graph error in old TS"
     | "Too many errors in old TS"
+    | "Language service disabled in new TS"
     | "Detected interesting changes"
     | "Detected no interesting changes"
     ;
@@ -70,10 +78,267 @@ export type RepoStatus =
 interface RepoResult {
     readonly status: RepoStatus;
     readonly summary?: string;
+    readonly replayScriptPath?: string;
+}
+
+function logStepTime(diagnosticOutput: boolean, repo: git.Repo, step: string, start: number): void {
+    if (diagnosticOutput) {
+        const end = performance.now();
+        console.log(`PERF { "repo": "${repo.url ?? repo.name}", "step": "${step}", "time": ${Math.round(end - start)} }`);
+    }
+}
+
+async function cloneRepo(
+    repo: git.Repo,
+    userTestsDir: string,
+    downloadDir: string,
+    diagnosticOutput: boolean): Promise<boolean> {
+    const cloneStart = performance.now();
+    try {
+        const isUserTestRepo = !repo.url;
+        if (isUserTestRepo) {
+            await ut.copyUserRepo(downloadDir, userTestsDir, repo);
+        }
+        else {
+            try {
+                console.log("Cloning if absent");
+                await git.cloneRepoIfNecessary(downloadDir, repo);
+            }
+            catch (err) {
+                reportError(err, "Error cloning " + repo.url);
+                return false;
+            }
+        }
+
+        return true;
+    } finally {
+        logStepTime(diagnosticOutput, repo, "clone", cloneStart);
+    }
+}
+
+async function installPackagesAndGetCommands(
+    repo: git.Repo,
+    downloadDir: string,
+    repoDir: string,
+    cleanOnFailure: boolean,
+    diagnosticOutput: boolean): Promise<ip.InstallCommand[] | undefined> {
+    const packageInstallStart = performance.now();
+    try {
+        console.log("Installing packages if absent");
+        const isUserTestRepo = !repo.url;
+        const commands = await ip.installPackages(
+            repoDir,
+                /*ignoreScripts*/ true,
+                /*quietOutput*/ !diagnosticOutput,
+                /*recursiveSearch*/ !isUserTestRepo,
+                /*lernaPackages*/ undefined,
+            repo.types);
+        await installPackages(repoDir, commands, packageTimeout);
+        return commands;
+    }
+    catch (err) {
+        reportError(err, `Error installing packages for ${repo.name}`);
+        if (/ENOSPC/.test(String(err))) {
+            await reportResourceUsage(downloadDir);
+        }
+
+        if (cleanOnFailure) {
+            // It's perfectly reasonable to run the server against a repo with only some packages installed,
+            // but making that mode repro-able could be complicated, so remove all packages for simplicity.
+            console.log("Removing installed packages");
+            await execAsync(repoDir, "git clean -xdff");
+            return [];
+        }
+        else {
+            return undefined;
+        }
+    }
+    finally {
+        logStepTime(diagnosticOutput, repo, "package install", packageInstallStart);
+    }
+}
+
+async function getTsServerRepoResult(
+    repo: git.Repo,
+    userTestsDir: string,
+    oldTsServerPath: string,
+    newTsServerPath: string,
+    downloadDir: string,
+    replayScriptArtifactPath: string,
+    diagnosticOutput: boolean): Promise<RepoResult> {
+
+    if (!await cloneRepo(repo, userTestsDir, downloadDir, diagnosticOutput)) {
+        return { status: "Git clone failed" };
+    }
+
+    const repoDir = path.join(downloadDir, repo.name);
+
+    // Presumably, people occasionally browse repos without installing the packages first
+    const installCommands = (Math.random() > 0.2)
+        ? (await installPackagesAndGetCommands(repo, downloadDir, repoDir, /*cleanOnFailure*/ true, diagnosticOutput))!
+        : [];
+
+    const isUserTestRepo = !repo.url;
+
+    const replayScriptName = path.basename(replayScriptArtifactPath);
+    const replayScriptPath = path.join(downloadDir, replayScriptName);
+
+    const lsStart = performance.now();
+    try {
+        console.log(`Testing with ${newTsServerPath} (new)`);
+        const newSpawnResult = await spawnWithTimeoutAsync(repoDir, process.argv[0], [path.join(__dirname, "utils", "exerciseServer.js"), repoDir, replayScriptPath, newTsServerPath, diagnosticOutput.toString()], executionTimeout);
+        if (!newSpawnResult) {
+            // CONSIDER: It might be interesting to treat timeouts as failures, but they'd be harder to baseline and more likely to have flaky repros
+            console.log(`New server timed out after ${executionTimeout} ms`);
+            return { status: "Unknown failure" };
+        }
+
+        if (diagnosticOutput) {
+            console.log("Raw spawn results (new):");
+            dumpSpawnResult(newSpawnResult);
+        }
+
+        switch (newSpawnResult.code) {
+            case 0:
+            case null:
+                if (newSpawnResult.signal !== null) {
+                    console.log(`Exited with signal ${newSpawnResult.signal}`);
+                    return { status: "Unknown failure" };
+                }
+
+                console.log("No issues found");
+                return { status: "Detected no interesting changes" };
+            case exercise.EXIT_LANGUAGE_SERVICE_DISABLED:
+                console.log("Skipping since language service was disabled");
+                return { status: "Language service disabled in new TS" };
+            case exercise.EXIT_SERVER_CRASH:
+            case exercise.EXIT_SERVER_ERROR:
+            case exercise.EXIT_SERVER_EXIT_FAILED:
+                // These deserve to be mentioned in the summary
+                break;
+            case exercise.EXIT_BAD_ARGS:
+            case exercise.EXIT_UNHANDLED_EXCEPTION:
+            default:
+                console.log(`Exited with code ${newSpawnResult.code}`);
+                return { status: "Unknown failure" };
+        }
+
+        console.log(`Issue found in ${newTsServerPath} (new):`);
+        console.log(insetLines(prettyPrintServerHarnessOutput(newSpawnResult.stdout, /*filter*/ false)));
+
+        console.log(`Testing with ${oldTsServerPath} (old)`);
+        const oldSpawnResult = await spawnWithTimeoutAsync(repoDir, process.argv[0], [path.join(__dirname, "..", "node_modules", "@typescript", "server-replay", "replay.js"), repoDir, replayScriptPath, oldTsServerPath, "-u"], executionTimeout);
+
+        if (diagnosticOutput && oldSpawnResult) {
+            console.log("Raw spawn results (old):");
+            dumpSpawnResult(oldSpawnResult);
+        }
+
+        // NB: Unlike newServerFailed, this includes timeouts because "it used to timeout" is useful context for an error in the new server
+        const oldServerFailed = !oldSpawnResult || !!oldSpawnResult.code || !!oldSpawnResult.signal;
+
+        if (oldServerFailed) {
+            console.log(`Issue found in ${oldTsServerPath} (old):`);
+            console.log(
+                insetLines(
+                    oldSpawnResult?.stdout
+                        ? prettyPrintServerHarnessOutput(oldSpawnResult.stdout, /*filter*/ false)
+                        : `Timed out after ${executionTimeout} ms`));
+        }
+
+        const owner = repo.owner ? `${repo.owner}/` : "";
+        const url = repo.url ? `(${repo.url})` : "";
+
+        let summary = `# [${owner}${repo.name}]${url}\n`;
+
+        summary += `## Repro Steps\n`;
+
+        // Markdown doesn't seem to support a <details> list item, so this chunk is in HTML
+
+        summary += "<ol>\n";
+        if (isUserTestRepo) {
+            summary += `<li>Download user test <code>${repo.name}</code></li>\n`;
+        }
+        else {
+            summary += `<li><code>git clone ${repo.url}</code></li>\n`;
+
+            try {
+                console.log("Extracting commit SHA for repro steps");
+                const commit = (await execAsync(repoDir, `git rev-parse @`)).trim();
+                summary += `<li>In dir <code>${repo.name}</code>, run <code>git reset --hard ${commit}</code></li>\n`;
+            }
+            catch {
+            }
+        }
+
+        if (installCommands.length > 1) {
+            summary += "<li><details><summary>Install packages</summary><ol>\n";
+        }
+        for (const command of installCommands) {
+            summary += `  <li>In dir <code>${path.relative(downloadDir, command.directory)}</code>, run <code>${command.tool} ${command.arguments.join(" ")}</code></li>\n`;
+        }
+        if (installCommands.length > 1) {
+            summary += "</ol></details>\n";
+        }
+
+        // The URL of the artifact can be determined via AzDO REST APIs, but not until after the artifact is published
+        summary += `<li>Download <code>${replayScriptArtifactPath}</code> from the <a href="${artifactFolderUrlPlaceholder}">artifact folder</a></li>\n`;
+        summary += `<li><code>npm install --no-save @typescript/server-replay</code></li>\n`;
+        summary += `<li><code>npx tsreplay ./${repo.name} ./${replayScriptName} path/to/tsserver.js</code></li>\n`;
+        summary += "</ol>\n";
+
+        summary += `
+<details>
+<summary>Last few requests</summary>
+
+\`\`\`json
+${fs.readFileSync(replayScriptPath, { encoding: "utf-8" }).split(/\r?\n/).slice(-5).join("\n")}
+\`\`\`
+
+</details>
+
+`;
+
+        summary += `
+## Error
+
+\`\`\`
+${prettyPrintServerHarnessOutput(newSpawnResult.stdout, /*filter*/ true)}
+\`\`\`
+
+`;
+
+        if (oldServerFailed) {
+            const oldServerError = oldSpawnResult?.stdout
+                ? prettyPrintServerHarnessOutput(oldSpawnResult.stdout, /*filter*/ true)
+                : `Timed out after ${executionTimeout} ms`;
+            summary += `
+<details>
+<summary>:warning: Note that ${path.basename(path.dirname(path.dirname(oldTsServerPath)))} also had errors :warning:</summary>
+
+\`\`\`
+${oldServerError}
+\`\`\`
+
+</details>
+
+`;
+        }
+
+        return { status: "Detected interesting changes", summary, replayScriptPath };
+    }
+    catch (err) {
+        reportError(err, `Error running tsserver on ${repo.url ?? repo.name}`);
+        return { status: "Unknown failure" };
+    }
+    finally {
+        console.log(`Done ${repo.url ?? repo.name}`);
+        logStepTime(diagnosticOutput, repo, "language service", lsStart);
+    }
 }
 
 // Exported for testing
-export async function getRepoResult(
+export async function getTscRepoResult(
     repo: git.Repo,
     userTestsDir: string,
     oldTscPath: string,
@@ -85,248 +350,187 @@ export async function getRepoResult(
      */
     buildWithNewWhenOldFails: boolean,
     downloadDir: string,
-    isDownloadDirOnTmpFs: boolean,
     diagnosticOutput: boolean): Promise<RepoResult> {
 
-    if (isDownloadDirOnTmpFs) {
-        await execAsync(processCwd, "sudo mount -t tmpfs -o size=4g tmpfs " + downloadDir);
+    if (!await cloneRepo(repo, userTestsDir, downloadDir, diagnosticOutput)) {
+        return { status: "Git clone failed" };
     }
 
+    const repoDir = path.join(downloadDir, repo.name);
+
+    if (!await installPackagesAndGetCommands(repo, downloadDir, repoDir, /*cleanOnFailure*/ false, diagnosticOutput)) {
+        return { status: "Package install failed" };
+    }
+
+    const isUserTestRepo = !repo.url;
+
+    const buildStart = performance.now();
     try {
-        const isUserTestRepo = !repo.url;
+        console.log(`Building with ${oldTscPath} (old)`);
+        const oldErrors = await ge.buildAndGetErrors(repoDir, isUserTestRepo, oldTscPath, executionTimeout, /*skipLibCheck*/ true);
 
-        const cloneStart = performance.now();
-        try {
-            if (isUserTestRepo) {
-                await ut.copyUserRepo(downloadDir, userTestsDir, repo);
-            }
-            else {
-                try {
-                    console.log("Cloning if absent");
-                    await git.cloneRepoIfNecessary(downloadDir, repo);
-                }
-                catch (err) {
-                    reportError(err, "Error cloning " + repo.url);
-                    return { status: "Git clone failed" };
-                }
-            }
-        } finally {
-            logStepTime("clone", cloneStart);
+        if (oldErrors.hasConfigFailure) {
+            console.log("Unable to build project graph");
+            console.log(`Skipping build with ${newTscPath} (new)`);
+            return { status: "Project-graph error in old TS" };
         }
 
-        const repoDir = path.join(downloadDir, repo.name);
+        const numProjects = oldErrors.projectErrors.length;
 
-        const packageInstallStart = performance.now();
-        try {
-            console.log("Installing packages if absent");
-            await installPackages(repoDir, /*recursiveSearch*/ !isUserTestRepo, packageTimeout, /*quietOutput*/ !diagnosticOutput, repo.types);
-        }
-        catch (err) {
-            reportError(err, `Error installing packages for ${repo.name}`);
-            if (diagnosticOutput || /ENOSPC/.test(String(err))) {
-                await reportResourceUsage(downloadDir);
+        let numFailed = 0;
+        for (const oldProjectErrors of oldErrors.projectErrors) {
+            if (oldProjectErrors.hasBuildFailure || oldProjectErrors.errors.length) {
+                numFailed++;
             }
-            return { status: "Package install failed" };
-        }
-        finally {
-            logStepTime("package install", packageInstallStart);
         }
 
-        const buildStart = performance.now();
-        try {
-            console.log(`Building with ${oldTscPath} (old)`);
-            const oldErrors = await ge.buildAndGetErrors(repoDir, isUserTestRepo, oldTscPath, executionTimeout, /*skipLibCheck*/ true);
+        if (!buildWithNewWhenOldFails && numFailed === numProjects) {
+            console.log(`Skipping build with ${newTscPath} (new)`);
+            return { status: "Too many errors in old TS" };
+        }
 
-            if (oldErrors.hasConfigFailure) {
-                console.log("Unable to build project graph");
-                console.log(`Skipping build with ${newTscPath} (new)`);
-                return { status: "Project-graph error in old TS" };
-            }
+        let sawDifferentErrors = false;
+        const owner = repo.owner ? `${repo.owner}/` : "";
+        const url = repo.url ?? "";
 
-            const numProjects = oldErrors.projectErrors.length;
-
-            let numFailed = 0;
-            for (const oldProjectErrors of oldErrors.projectErrors) {
-                if (oldProjectErrors.hasBuildFailure || oldProjectErrors.errors.length) {
-                    numFailed++;
-                }
-            }
-
-            if (!buildWithNewWhenOldFails && numFailed === numProjects) {
-                console.log(`Skipping build with ${newTscPath} (new)`);
-                return { status: "Too many errors in old TS" };
-            }
-
-            let sawDifferentErrors = false;
-            const owner = repo.owner ? `${repo.owner}/` : "";
-            const url = repo.url ?? "";
-
-            let summary = `<details open="true">
+        let summary = `<details open="true">
 <summary>
 <h2><a href="${url}">${owner}${repo.name}</a></h2>
 </summary>
 
 `;
 
-            if (!buildWithNewWhenOldFails && numFailed > 0) {
-                const oldFailuresMessage = `${numFailed} of ${numProjects} projects failed to build with the old tsc and were ignored`;
-                console.log(oldFailuresMessage);
-                summary += `**${oldFailuresMessage}**\n`;
-            }
-
-            console.log(`Building with ${newTscPath} (new)`);
-            const newErrors = await ge.buildAndGetErrors(repoDir, isUserTestRepo, newTscPath, executionTimeout, /*skipLibCheck*/ true);
-
-            if (newErrors.hasConfigFailure) {
-                console.log("Unable to build project graph");
-
-                // This doesn't depend on tsc at all, so it shouldn't be possible for it to fail.
-                // Throw so we don't get confusing results if the seemingly impossible happens.
-                throw new Error("Project graph changed between builds");
-            }
-
-            console.log("Comparing errors");
-            for (const oldProjectErrors of oldErrors.projectErrors) {
-                if (!buildWithNewWhenOldFails && (oldProjectErrors.hasBuildFailure || oldProjectErrors.errors.length)) {
-                    continue;
-                }
-
-                const { projectUrl, isComposite } = oldProjectErrors;
-
-                // TS 5055 generally indicates that the project can't be built twice in a row without cleaning in between.
-                const newErrorList = newErrors.projectErrors.find(pe => pe.projectUrl == projectUrl)?.errors?.filter(e => e.code !== 5055) ?? [];
-                const oldErrorList = oldProjectErrors.errors;
-
-                console.log(`Error counts for ${projectUrl}: new = ${newErrorList.length}, old = ${oldErrorList.length}`);
-
-                // If both succeeded, there's nothing interesting to report.
-                // Sneakiness: if !buildWithNewWhenOldFails, then we already know oldErrorList is empty.
-                if (!oldErrorList.length && !newErrorList.length) {
-                    continue;
-                }
-
-                const newlyReported = newErrorList.filter(ne => !oldErrorList.find(oe => ge.errorEquals(oe, ne)));
-                const newlyUnreported = buildWithNewWhenOldFails ? oldErrorList.filter(oe => !newErrorList.find(ne => ge.errorEquals(ne, oe))) : [];
-
-                // If the errors are exactly the same, there's nothing interesting to report.
-                if (!newlyReported.length && !newlyUnreported.length) {
-                    continue;
-                }
-
-                sawDifferentErrors = true;
-
-                const newlyReportedErrorMessageMap = new Map<string, ge.Error[]>();
-                const newlyReportedErrorMessages: string[] = [];
-
-                console.log(`New errors for ${isComposite ? "composite" : "non-composite"} project ${projectUrl}`);
-                for (const newError of newlyReported) {
-                    const newErrorText = newError.text;
-
-                    console.log(`\tTS${newError.code} at ${newError.fileUrl ?? "project scope"}${isComposite ? ` in ${projectUrl}` : ``}`);
-                    console.log(`\t\t${newErrorText}`);
-
-                    if (!newlyReportedErrorMessageMap.has(newErrorText)) {
-                        newlyReportedErrorMessageMap.set(newErrorText, []);
-                        newlyReportedErrorMessages.push(newErrorText);
-                    }
-
-                    newlyReportedErrorMessageMap.get(newErrorText)!.push(newError);
-                }
-
-                const newlyUnreportedErrorMessageMap = new Map<string, ge.Error[]>();
-                const newlyUnreportedErrorMessages: string[] = [];
-
-                console.log(`No-longer-reported errors for ${isComposite ? "composite" : "non-composite"} project ${projectUrl}`);
-                for (const oldError of newlyUnreported) {
-                    const oldErrorText = oldError.text;
-
-                    console.log(`\tTS${oldError.code} at ${oldError.fileUrl ?? "project scope"}${isComposite ? ` in ${oldError.projectUrl}` : ``}`);
-                    console.log(`\t\t${oldErrorText}`);
-
-                    if (!newlyUnreportedErrorMessageMap.has(oldErrorText)) {
-                        newlyUnreportedErrorMessageMap.set(oldErrorText, []);
-                        newlyUnreportedErrorMessages.push(oldErrorText);
-                    }
-
-                    newlyUnreportedErrorMessageMap.get(oldErrorText)!.push(oldError);
-                }
-
-                summary += `### ${makeMarkdownLink(projectUrl)}\n`;
-
-                for (const errorMessage of newlyReportedErrorMessages) {
-                    summary += ` - ${buildWithNewWhenOldFails ? "[NEW] " : ""}\`${errorMessage}\`\n`;
-
-                    for (const error of newlyReportedErrorMessageMap.get(errorMessage)!) {
-                        summary += `   - ${error.fileUrl ? makeMarkdownLink(error.fileUrl) : "Project Scope"}${isComposite ? ` in ${makeMarkdownLink(error.projectUrl)}` : ``}\n`;
-                    }
-                }
-
-                for (const errorMessage of newlyUnreportedErrorMessages) {
-                    summary += ` - ${buildWithNewWhenOldFails ? "[MISSING] " : ""}\`${errorMessage}\`\n`;
-
-                    for (const error of newlyUnreportedErrorMessageMap.get(errorMessage)!) {
-                        summary += `   - ${error.fileUrl ? makeMarkdownLink(error.fileUrl) : "Project Scope"}${isComposite ? ` in ${makeMarkdownLink(error.projectUrl)}` : ``}\n`;
-                    }
-                }
-            }
-
-            summary += "\n</details>\n";
-
-            if (sawDifferentErrors) {
-                return { status: "Detected interesting changes", summary };
-            }
-        }
-        catch (err) {
-            reportError(err, `Error building ${repo.url ?? repo.name}`);
-            return { status: "Unknown failure" };
-        }
-        finally {
-            logStepTime("build", buildStart);
+        if (!buildWithNewWhenOldFails && numFailed > 0) {
+            const oldFailuresMessage = `${numFailed} of ${numProjects} projects failed to build with the old tsc and were ignored`;
+            console.log(oldFailuresMessage);
+            summary += `**${oldFailuresMessage}**\n`;
         }
 
-        console.log(`Done ${repo.url ?? repo.name}`);
-        return { status: "Detected no interesting changes" };
+        console.log(`Building with ${newTscPath} (new)`);
+        const newErrors = await ge.buildAndGetErrors(repoDir, isUserTestRepo, newTscPath, executionTimeout, /*skipLibCheck*/ true);
+
+        if (newErrors.hasConfigFailure) {
+            console.log("Unable to build project graph");
+
+            // This doesn't depend on tsc at all, so it shouldn't be possible for it to fail.
+            // Throw so we don't get confusing results if the seemingly impossible happens.
+            throw new Error("Project graph changed between builds");
+        }
+
+        console.log("Comparing errors");
+        for (const oldProjectErrors of oldErrors.projectErrors) {
+            if (!buildWithNewWhenOldFails && (oldProjectErrors.hasBuildFailure || oldProjectErrors.errors.length)) {
+                continue;
+            }
+
+            const { projectUrl, isComposite } = oldProjectErrors;
+
+            // TS 5055 generally indicates that the project can't be built twice in a row without cleaning in between.
+            const newErrorList = newErrors.projectErrors.find(pe => pe.projectUrl == projectUrl)?.errors?.filter(e => e.code !== 5055) ?? [];
+            const oldErrorList = oldProjectErrors.errors;
+
+            console.log(`Error counts for ${projectUrl}: new = ${newErrorList.length}, old = ${oldErrorList.length}`);
+
+            // If both succeeded, there's nothing interesting to report.
+            // Sneakiness: if !buildWithNewWhenOldFails, then we already know oldErrorList is empty.
+            if (!oldErrorList.length && !newErrorList.length) {
+                continue;
+            }
+
+            const newlyReported = newErrorList.filter(ne => !oldErrorList.find(oe => ge.errorEquals(oe, ne)));
+            const newlyUnreported = buildWithNewWhenOldFails ? oldErrorList.filter(oe => !newErrorList.find(ne => ge.errorEquals(ne, oe))) : [];
+
+            // If the errors are exactly the same, there's nothing interesting to report.
+            if (!newlyReported.length && !newlyUnreported.length) {
+                continue;
+            }
+
+            sawDifferentErrors = true;
+
+            const newlyReportedErrorMessageMap = new Map<string, ge.Error[]>();
+            const newlyReportedErrorMessages: string[] = [];
+
+            console.log(`New errors for ${isComposite ? "composite" : "non-composite"} project ${projectUrl}`);
+            for (const newError of newlyReported) {
+                const newErrorText = newError.text;
+
+                console.log(`\tTS${newError.code} at ${newError.fileUrl ?? "project scope"}${isComposite ? ` in ${projectUrl}` : ``}`);
+                console.log(`\t\t${newErrorText}`);
+
+                if (!newlyReportedErrorMessageMap.has(newErrorText)) {
+                    newlyReportedErrorMessageMap.set(newErrorText, []);
+                    newlyReportedErrorMessages.push(newErrorText);
+                }
+
+                newlyReportedErrorMessageMap.get(newErrorText)!.push(newError);
+            }
+
+            const newlyUnreportedErrorMessageMap = new Map<string, ge.Error[]>();
+            const newlyUnreportedErrorMessages: string[] = [];
+
+            console.log(`No-longer-reported errors for ${isComposite ? "composite" : "non-composite"} project ${projectUrl}`);
+            for (const oldError of newlyUnreported) {
+                const oldErrorText = oldError.text;
+
+                console.log(`\tTS${oldError.code} at ${oldError.fileUrl ?? "project scope"}${isComposite ? ` in ${oldError.projectUrl}` : ``}`);
+                console.log(`\t\t${oldErrorText}`);
+
+                if (!newlyUnreportedErrorMessageMap.has(oldErrorText)) {
+                    newlyUnreportedErrorMessageMap.set(oldErrorText, []);
+                    newlyUnreportedErrorMessages.push(oldErrorText);
+                }
+
+                newlyUnreportedErrorMessageMap.get(oldErrorText)!.push(oldError);
+            }
+
+            summary += `### ${makeMarkdownLink(projectUrl)}\n`;
+
+            for (const errorMessage of newlyReportedErrorMessages) {
+                summary += ` - ${buildWithNewWhenOldFails ? "[NEW] " : ""}\`${errorMessage}\`\n`;
+
+                for (const error of newlyReportedErrorMessageMap.get(errorMessage)!) {
+                    summary += `   - ${error.fileUrl ? makeMarkdownLink(error.fileUrl) : "Project Scope"}${isComposite ? ` in ${makeMarkdownLink(error.projectUrl)}` : ``}\n`;
+                }
+            }
+
+            for (const errorMessage of newlyUnreportedErrorMessages) {
+                summary += ` - ${buildWithNewWhenOldFails ? "[MISSING] " : ""}\`${errorMessage}\`\n`;
+
+                for (const error of newlyUnreportedErrorMessageMap.get(errorMessage)!) {
+                    summary += `   - ${error.fileUrl ? makeMarkdownLink(error.fileUrl) : "Project Scope"}${isComposite ? ` in ${makeMarkdownLink(error.projectUrl)}` : ``}\n`;
+                }
+            }
+        }
+
+        summary += "\n</details>\n";
+
+        if (sawDifferentErrors) {
+            return { status: "Detected interesting changes", summary };
+        }
+    }
+    catch (err) {
+        reportError(err, `Error building ${repo.url ?? repo.name}`);
+        return { status: "Unknown failure" };
     }
     finally {
-        // Throw away the repo so we don't run out of space
-        // Note that we specifically don't recover and attempt another repo if this fails
-        console.log("Cleaning up repo");
-        if (isDownloadDirOnTmpFs) {
-            if (diagnosticOutput) {
-                // Dump any processes holding onto the download directory in case umount fails
-                await execAsync(processCwd, `lsof | grep ${downloadDir} || true`);
-            }
-            try {
-                await execAsync(processCwd, "sudo umount " + downloadDir);
-            }
-            catch (e) {
-                await execAsync(processCwd, `pstree -palT ${processPid}`);
-                throw e;
-            }
-            if (diagnosticOutput) {
-                await reportResourceUsage(downloadDir);
-            }
-        }
+        logStepTime(diagnosticOutput, repo, "build", buildStart);
     }
 
-    function logStepTime(step: string, start: number): void {
-        if (diagnosticOutput) {
-            const end = performance.now();
-            console.log(`PERF { "repo": "${repo.url ?? repo.name}", "step": "${step}", "time": ${Math.round(end - start)} }`);
-        }
-    }
+    return { status: "Detected no interesting changes" };
 }
 
 export const metadataFileName = "metadata.json";
 export const resultFileNameSuffix = "results.txt";
+export const replayScriptFileNameSuffix = "replay.txt";
+export const artifactFolderUrlPlaceholder = "PLACEHOLDER_ARTIFACT_FOLDER";
 
 export type StatusCounts = {
     [P in RepoStatus]?: number
 };
 
 export interface Metadata {
-    readonly newTscResolvedVersion: string;
-    readonly oldTscResolvedVersion: string;
+    readonly newTsResolvedVersion: string;
+    readonly oldTsResolvedVersion: string;
     readonly statusCounts: StatusCounts;
 }
 
@@ -341,9 +545,7 @@ function getWorkerRepos(allRepos: readonly git.Repo[], workerCount: number, work
 }
 
 export async function mainAsync(params: GitParams | UserParams): Promise<void> {
-    const { testType } = params;
-
-    const downloadDir = params.tmpfs ? "/mnt/ts_downloads" : "./ts_downloads";
+    const downloadDir = params.tmpfs ? "/mnt/ts_downloads" : path.join(processCwd, "ts_downloads");
     // TODO: check first whether the directory exists and skip downloading if possible
     // TODO: Seems like this should come after the typescript download
     if (params.tmpfs)
@@ -351,19 +553,21 @@ export async function mainAsync(params: GitParams | UserParams): Promise<void> {
     else
         await execAsync(processCwd, "mkdir " + downloadDir);
 
-    if (!(await pu.exists(params.resultDirPath))) {
-        await fs.promises.mkdir(params.resultDirPath, { recursive: true });
+    const resultDirPath = path.join(processCwd, params.resultDirName);
+
+    if (!(await pu.exists(resultDirPath))) {
+        await fs.promises.mkdir(resultDirPath, { recursive: true });
     }
 
     // TODO: Only download if the commit has changed (need to map refs to commits and then download to typescript-COMMIT instead)
-    const { oldTscPath, oldTscResolvedVersion, newTscPath, newTscResolvedVersion } = await downloadTypeScriptAsync(processCwd, params);
+    const { oldTsEntrypointPath, oldTsResolvedVersion, newTsEntrypointPath, newTsResolvedVersion } = await downloadTsAsync(processCwd, params);
 
     // Get the name of the typescript folder.
-    const oldTscDirPath = path.resolve(oldTscPath, "../../");
-    const newTscDirPath = path.resolve(newTscPath, "../../");
+    const oldTscDirPath = path.resolve(oldTsEntrypointPath, "../../");
+    const newTscDirPath = path.resolve(newTsEntrypointPath, "../../");
 
-    console.log("Old version = " + oldTscResolvedVersion);
-    console.log("New version = " + newTscResolvedVersion);
+    console.log("Old version = " + oldTsResolvedVersion);
+    console.log("New version = " + newTsResolvedVersion);
 
     const userTestsDir = path.join(processCwd, "userTests");
 
@@ -376,15 +580,51 @@ export async function mainAsync(params: GitParams | UserParams): Promise<void> {
     let i = 1;
     for (const repo of repos) {
         console.log(`Starting #${i++} / ${repos.length}: ${repo.url ?? repo.name}`);
+        if (params.tmpfs) {
+            await execAsync(processCwd, "sudo mount -t tmpfs -o size=4g tmpfs " + downloadDir);
+        }
 
-        const { status, summary } = await getRepoResult(repo, userTestsDir, oldTscPath, newTscPath, params.buildWithNewWhenOldFails, downloadDir, params.tmpfs, !!params.diagnosticOutput);
-        console.log(`Repo ${repo.url ?? repo.name} had status ${status}`);
-        statusCounts[status] = (statusCounts[status] ?? 0) + 1;
-        if (summary) {
-            const filename = repo.owner
-                ? `${repo.owner}.${repo.name}.${resultFileNameSuffix}`
-                : `${repo.name}.${resultFileNameSuffix}`;
-            await fs.promises.writeFile(path.join(params.resultDirPath, filename), summary, { encoding: "utf-8" });
+        const diagnosticOutput = !!params.diagnosticOutput;
+        try {
+            const repoPrefix = repo.owner
+                ? `${repo.owner}.${repo.name}`
+                : repo.name;
+            const replayScriptFileName = `${repoPrefix}.${replayScriptFileNameSuffix}`;
+            const { status, summary, replayScriptPath } = params.entrypoint === "tsc"
+                ? await getTscRepoResult(repo, userTestsDir, oldTsEntrypointPath, newTsEntrypointPath, params.buildWithNewWhenOldFails, downloadDir, diagnosticOutput)
+                : await getTsServerRepoResult(repo, userTestsDir, oldTsEntrypointPath, newTsEntrypointPath, downloadDir, path.join(params.resultDirName, replayScriptFileName), diagnosticOutput);
+            console.log(`Repo ${repo.url ?? repo.name} had status "${status}"`);
+            statusCounts[status] = (statusCounts[status] ?? 0) + 1;
+            if (summary) {
+
+                const resultFileName = `${repoPrefix}.${resultFileNameSuffix}`;
+                await fs.promises.writeFile(path.join(resultDirPath, resultFileName), summary, { encoding: "utf-8" });
+
+                // In practice, there will only be a replay script when the entrypoint is tsserver
+                // There can be replay steps without a summary, but then they're not interesting
+                if (replayScriptPath) {
+                    await fs.promises.copyFile(replayScriptPath, path.join(resultDirPath, replayScriptFileName));
+                }
+            }
+
+        }
+        finally {
+            // Throw away the repo so we don't run out of space
+            // Note that we specifically don't recover and attempt another repo if this fails
+            console.log("Cleaning up repo");
+            if (params.tmpfs) {
+                if (diagnosticOutput) {
+                    // Dump any processes holding onto the download directory in case umount fails
+                    await execAsync(processCwd, `lsof -K i | grep ${downloadDir} || true`);
+                }
+                try {
+                    await execAsync(processCwd, "sudo umount " + downloadDir);
+                }
+                catch (e) {
+                    await execAsync(processCwd, `pstree -palT`);
+                    throw e;
+                }
+            }
         }
     }
 
@@ -405,19 +645,18 @@ export async function mainAsync(params: GitParams | UserParams): Promise<void> {
     }
 
     const metadata: Metadata = {
-        newTscResolvedVersion,
-        oldTscResolvedVersion,
+        newTsResolvedVersion: newTsResolvedVersion,
+        oldTsResolvedVersion: oldTsResolvedVersion,
         statusCounts,
     };
-    await fs.promises.writeFile(path.join(params.resultDirPath, metadataFileName), JSON.stringify(metadata), { encoding: "utf-8" });
+    await fs.promises.writeFile(path.join(resultDirPath, metadataFileName), JSON.stringify(metadata), { encoding: "utf-8" });
 }
 
-async function installPackages(repoDir: string, recursiveSearch: boolean, timeoutMs: number, quietOutput: boolean, types?: string[]) {
+async function installPackages(repoDir: string, commands: readonly ip.InstallCommand[], timeoutMs: number) {
     let usedYarn = false;
     try {
         let timedOut = false;
         const startMs = performance.now();
-        const commands = await ip.installPackages(repoDir, /*ignoreScripts*/ true, quietOutput, recursiveSearch, /*lernaPackages*/ undefined, types);
         for (const { directory: packageRoot, tool, arguments: args } of commands) {
             if (timedOut) break;
 
@@ -446,9 +685,9 @@ async function installPackages(repoDir: string, recursiveSearch: boolean, timeou
                 const errorText = `Exited with ${spawnResult.code ? `code ${spawnResult.code}` : `signal ${spawnResult.signal}`}
 ${spawnResult.stdout.trim() || "No stdout"}\n${spawnResult.stderr.trim() || "No stderr"}`;
 
-                if (/(?:ex|s)amples?\//i.test(packageRootDescription) || /tests?\//i.test(packageRootDescription)) {
+                if (!/ENOSPC/.test(errorText) && (/(?:ex|s)amples?\//i.test(packageRootDescription) || /tests?\//i.test(packageRootDescription))) {
                     console.log(`Ignoring package install error from non-product folder ${packageRootDescription}:`);
-                    console.log(sanitizeErrorText(errorText));
+                    console.log(insetLines(reduceSpew(errorText)));
                 }
                 else {
                     throw new Error(`Failed to install packages for ${packageRootDescription}:\n${errorText}`);
@@ -482,16 +721,58 @@ async function reportResourceUsage(downloadDir: string) {
 export function reportError(err: any, message: string) {
     console.log(`${message}:`);
     if (err.message && err.stack && err.stack.indexOf(err.message) >= 0) {
-        console.log(sanitizeErrorText(err.stack));
+        console.log(insetLines(reduceSpew(err.stack)));
     }
     else {
-        console.log(sanitizeErrorText(err.message ?? "No message"));
-        console.log(sanitizeErrorText(err.stack ?? "Unknown Stack"));
+        console.log(insetLines(reduceSpew(err.message ?? "No message")));
+        console.log(insetLines(err.stack ?? "Unknown Stack"));
     }
 }
 
-function sanitizeErrorText(text: string): string {
-    return reduceSpew(text).replace(/(^|\n)/g, "$1> ");
+function dumpSpawnResult(spawnResult: SpawnResult): void {
+    console.log(`ExitCode: ${spawnResult.code}
+Signal: ${spawnResult.signal}
+stdout:
+>>>
+${spawnResult.stdout}
+<<<
+stderr:
+>>>
+${spawnResult.stderr}
+<<<
+`);
+}
+
+function prettyPrintServerHarnessOutput(error: string, filter: boolean): string {
+    try {
+        const errorObj = JSON.parse(error);
+        if (errorObj.message) {
+            return `Req #${errorObj.request_seq} - ${errorObj.command}
+${filter ? filterToTsserverLines(errorObj.message) : errorObj.message}`;
+        }
+
+        // It's not really clear how this could happen, but reporting the whole repsonse should be fine
+        // if there's no message property
+        return JSON.stringify(errorObj, undefined, 2);
+    }
+    catch {
+        // Sometimes, the response isn't JSON and that's fine
+        return error;
+    }
+}
+
+function filterToTsserverLines(stackLines: string): string {
+    const tsserverRegex = /^.*tsserver\.js.*$/mg;
+    let tsserverLines = "";
+    let match;
+    while (match = tsserverRegex.exec(stackLines)) {
+        tsserverLines += match[0].replace(processCwd, "") + "\n";
+    }
+    return tsserverLines.trimEnd();
+}
+
+function insetLines(text: string): string {
+    return text.trimEnd().replace(/(^|\n)/g, "$1> ");
 }
 
 function reduceSpew(message: string): string {
@@ -507,49 +788,49 @@ function makeMarkdownLink(url: string) {
         : `[${match[1]}](${url})`;
 }
 
-async function downloadTypeScriptAsync(cwd: string, params: GitParams | UserParams): Promise<{ oldTscPath: string, oldTscResolvedVersion: string, newTscPath: string, newTscResolvedVersion: string }> {
-    if (params.testType === 'user') {
-        const { tscPath: oldTscPath, resolvedVersion: oldTscResolvedVersion } = await downloadTypescriptRepoAsync(cwd, params.oldTypescriptRepoUrl, params.oldHeadRef);
+async function downloadTsAsync(cwd: string, params: GitParams | UserParams): Promise<{ oldTsEntrypointPath: string, oldTsResolvedVersion: string, newTsEntrypointPath: string, newTsResolvedVersion: string }> {
+    const entrypoint = params.entrypoint;
+    if (params.testType === "user") {
+        const { tsEntrypointPath: oldTsEntrypointPath, resolvedVersion: oldTsResolvedVersion } = await downloadTsRepoAsync(cwd, params.oldTsRepoUrl, params.oldHeadRef, entrypoint);
         // We need to handle the ref/pull/*/merge differently as it is not a branch and cannot be pulled during clone.
-        const { tscPath: newTscPath, resolvedVersion: newTscResolvedVersion } = await downloadTypescriptPrAsync(cwd, params.oldTypescriptRepoUrl, params.prNumber);
+        const { tsEntrypointPath: newTsEntrypointPath, resolvedVersion: newTsResolvedVersion } = await downloadTsPrAsync(cwd, params.oldTsRepoUrl, params.prNumber, entrypoint);
 
         return {
-            oldTscPath,
-            oldTscResolvedVersion,
-            newTscPath,
-            newTscResolvedVersion
+            oldTsEntrypointPath,
+            oldTsResolvedVersion,
+            newTsEntrypointPath,
+            newTsResolvedVersion
         };
     }
-    else if (params.testType === 'git') {
-        const { tscPath: oldTscPath, resolvedVersion: oldTscResolvedVersion } = await downloadTypeScriptNpmAsync(cwd, params.oldTscVersion);
-        const { tscPath: newTscPath, resolvedVersion: newTscResolvedVersion } = await downloadTypeScriptNpmAsync(cwd, params.newTscVersion);
+    else if (params.testType === "github") {
+        const { tsEntrypointPath: oldTsEntrypointPath, resolvedVersion: oldTsResolvedVersion } = await downloadTsNpmAsync(cwd, params.oldTsNpmVersion, entrypoint);
+        const { tsEntrypointPath: newTsEntrypointPath, resolvedVersion: newTsResolvedVersion } = await downloadTsNpmAsync(cwd, params.newTsNpmVersion, entrypoint);
 
         return {
-            oldTscPath,
-            oldTscResolvedVersion,
-            newTscPath,
-            newTscResolvedVersion
+            oldTsEntrypointPath,
+            oldTsResolvedVersion,
+            newTsEntrypointPath,
+            newTsResolvedVersion
         };
     }
     else {
-        throw new Error('Invalid parameters');
+        throw new Error("Invalid parameters");
     }
 }
 
-export async function downloadTypescriptRepoAsync(cwd: string, repoUrl: string, headRef: string): Promise<{ tscPath: string, resolvedVersion: string }> {
+export async function downloadTsRepoAsync(cwd: string, repoUrl: string, headRef: string, target: TsEntrypoint): Promise<{ tsEntrypointPath: string, resolvedVersion: string }> {
     const repoName = `typescript-${headRef}`;
     await git.cloneRepoIfNecessary(cwd, { name: repoName, url: repoUrl, branch: headRef });
 
     const repoPath = path.join(cwd, repoName);
 
     return {
-        // tscPath: path.join(repoPath, "lib", "tsc.js"),// Handy for local testing
-        tscPath: await buildTsc(repoPath),
+        tsEntrypointPath: await buildTs(repoPath, target),
         resolvedVersion: headRef
     };
 }
 
-async function downloadTypescriptPrAsync(cwd: string, repoUrl: string, prNumber: number): Promise<{ tscPath: string, resolvedVersion: string }> {
+async function downloadTsPrAsync(cwd: string, repoUrl: string, prNumber: number, target: TsEntrypoint): Promise<{ tsEntrypointPath: string, resolvedVersion: string }> {
     const repoName = `typescript-${prNumber}`;
     await git.cloneRepoIfNecessary(cwd, { name: repoName, url: repoUrl });
 
@@ -559,24 +840,25 @@ async function downloadTypescriptPrAsync(cwd: string, repoUrl: string, prNumber:
     await git.checkout(repoPath, headRef);
 
     return {
-        // tscPath: path.join(repoPath, "lib", "tsc.js"),// Handy for local testing
-        tscPath: await buildTsc(repoPath),
+        tsEntrypointPath: await buildTs(repoPath, target),
         resolvedVersion: headRef
     };
 }
 
-async function buildTsc(repoPath: string) {
+async function buildTs(repoPath: string, entrypoint: TsEntrypoint) {
     await execAsync(repoPath, "npm ci");
-    await execAsync(repoPath, "npm run build:compiler");
+    await execAsync(repoPath, `npx gulp ${entrypoint}`);
 
-    // We build the LKG for the benefit of scenarios that want to install it as an npm package
-    await execAsync(repoPath, "npx gulp configure-insiders");
-    await execAsync(repoPath, "npx gulp LKG");
+    if (entrypoint === "tsc") {
+        // We build the LKG for the benefit of scenarios that want to install it as an npm package
+        await execAsync(repoPath, "npx gulp configure-insiders");
+        await execAsync(repoPath, "npx gulp LKG");
+    }
 
-    return path.join(repoPath, "built", "local", "tsc.js");
+    return path.join(repoPath, "built", "local", `${entrypoint}.js`);
 }
 
-async function downloadTypeScriptNpmAsync(cwd: string, version: string): Promise<{ tscPath: string, resolvedVersion: string }> {
+async function downloadTsNpmAsync(cwd: string, version: string, entrypoint: TsEntrypoint): Promise<{ tsEntrypointPath: string, resolvedVersion: string }> {
     const tarName = (await execAsync(cwd, `npm pack typescript@${version} --quiet`)).trim();
 
     const tarMatch = /^(typescript-(.+))\..+$/.exec(tarName);
@@ -591,10 +873,10 @@ async function downloadTypeScriptNpmAsync(cwd: string, version: string): Promise
     await execAsync(cwd, `tar xf ${tarName} && rm ${tarName}`);
     await fs.promises.rename(path.join(processCwd, "package"), dirPath);
 
-    const tscPath = path.join(dirPath, "lib", "tsc.js");
-    if (!await pu.exists(tscPath)) {
-        throw new Error("Cannot find file " + tscPath);
+    const tsEntrypointPath = path.join(dirPath, "lib", `${entrypoint}.js`);
+    if (!await pu.exists(tsEntrypointPath)) {
+        throw new Error("Cannot find file " + tsEntrypointPath);
     }
 
-    return { tscPath, resolvedVersion };
+    return { tsEntrypointPath, resolvedVersion };
 }

--- a/src/utils/execUtils.ts
+++ b/src/utils/execUtils.ts
@@ -58,6 +58,7 @@ export function spawnWithTimeoutAsync(cwd: string, command: string, args: readon
         childProcess.on("close", async (code, signal) => {
             // SIGTERM indicates timeout
             if (signal === "SIGTERM") {
+                // CONSIDER: Does this do anything?  Won't all child processes have PPID 1 by now, since the parent has exited?
                 await execAsync(path.join(__dirname, "..", "..", "scripts"), `./kill-children-of ${childProcess.pid}`);
                 resolve(undefined);
                 return;

--- a/src/utils/exerciseServer.ts
+++ b/src/utils/exerciseServer.ts
@@ -1,0 +1,424 @@
+// @ts-check
+
+import sh = require("@typescript/server-harness");
+import fs = require("fs");
+import process = require("process");
+import path = require("path");
+import glob = require("glob");
+import { performance } from "perf_hooks";
+import { EXIT_BAD_ARGS, EXIT_UNHANDLED_EXCEPTION, EXIT_SERVER_EXIT_FAILED, EXIT_SERVER_CRASH, EXIT_SERVER_ERROR, EXIT_LANGUAGE_SERVICE_DISABLED } from "./exerciseServerConstants";
+
+const testDirPlaceholder = "@PROJECT_ROOT@";
+
+const exitTimeoutMs = 5000;
+
+const argv = process.argv;
+
+if (argv.length !== 6) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <project_dir> <requests_path> <server_path> <diagnostic_output>`);
+    process.exit(EXIT_BAD_ARGS);
+}
+
+// CONVENTION: stderr is for output to the log; stdout is for output to the user
+
+const [, , testDir, replayScriptPath, tsserverPath, diag] = argv;
+const diagnosticOutput = diag.toLocaleLowerCase() === "true";
+
+exerciseServer(testDir, replayScriptPath, tsserverPath).catch(e => {
+    console.error(e);
+    process.exit(EXIT_UNHANDLED_EXCEPTION);
+});
+
+export async function exerciseServer(testDir: string, replayScriptPath: string, tsserverPath: string): Promise<void> {
+    const requestTimes: Record<string, number> = {};
+    const requestCounts: Record<string, number> = {};
+    const start = performance.now();
+
+    const oldCwd = process.cwd();
+    const replayScriptHandle = await fs.promises.open(replayScriptPath, "w");
+    try {
+        // Needed for excludedDirectories
+        process.chdir(testDir);
+        await exerciseServerWorker(testDir, tsserverPath, replayScriptHandle, requestTimes, requestCounts);
+    }
+    finally {
+        await replayScriptHandle.close();
+
+        process.chdir(oldCwd);
+
+        const end = performance.now();
+        if (diagnosticOutput) {
+            console.error(`Elapsed time ${Math.round(end - start)} ms`);
+            for (const command in requestTimes) {
+                console.error(`${command}:\t${Math.round(requestTimes[command])} ms (${requestCounts[command]} calls)`);
+            }
+        }
+    }
+}
+
+async function exerciseServerWorker(testDir: string, tsserverPath: string, replayScriptHandle: fs.promises.FileHandle, requestTimes: Record<string, number>, requestCounts: Record<string, number>): Promise<void> {
+    const files = await (new Promise<string[]>((resolve, reject) => {
+        glob("**/*.@(ts|tsx|js|jsx)", { cwd: testDir, absolute: false, ignore: ["**/node_modules/**"], nodir: true, follow: false }, (err, results) => {
+            if (err) {
+                reject(err);
+            }
+            else {
+                resolve(results);
+            }
+        });
+    }));
+
+    const serverArgs = [
+        "--disableAutomaticTypingAcquisition",
+    ];
+
+    replayScriptHandle.write(JSON.stringify({
+        rootDirPlaceholder: testDirPlaceholder,
+        serverArgs,
+    }) + "\n");
+
+    const server = sh.launchServer(
+        tsserverPath,
+        serverArgs,
+        [
+            "--max-old-space-size=4096",
+            "--expose-gc",
+        ]);
+
+    process.once("SIGTERM", () => {
+        exitExpected = true;
+        server.kill();
+        // This is a sneaky way to invoke node's default SIGTERM handler
+        process.kill(process.pid, "SIGTERM");
+    });
+
+    let loadedNewProject = false;
+    server.on("event", (e: any) => {
+        switch (e.event) {
+            case "projectLoadingFinish":
+                loadedNewProject = true;
+                break;
+            case "projectLanguageServiceState":
+                if (!e.body.languageServiceDisabled) {
+                    const languageServiceDisabledProject = e.body.projectName ? path.normalize(e.body.projectName) : "unknown project";
+                    console.error(`Language service disabled for ${languageServiceDisabledProject}`);
+                    exitExpected = true;
+                    server.kill();
+                    process.exit(EXIT_LANGUAGE_SERVICE_DISABLED);
+                }
+                break;
+        }
+    });
+
+    let exitExpected = false;
+    server.on("exit", (code: number | null) => {
+        if (!exitExpected) {
+            console.log(`Server exited prematurely with code ${code ?? "unknown"}`);
+            process.exit(EXIT_SERVER_CRASH);
+        }
+    });
+
+    let seq = 1;
+
+    try {
+        await message({
+            "command": "configure",
+            "arguments": {
+                "preferences": {
+                    "includePackageJsonAutoImports": "off" // Handle per-request instead
+                },
+                "watchOptions": {
+                    "excludeDirectories": ["**/node_modules"]
+                }
+            }
+        });
+
+        const openFileAbsolutePaths = [];
+
+        // NB: greater than 1 behaves the same as 1
+        const skipFileProb = 1000 / files.length;
+        for (const openFileRelativePath of files) {
+            if (Math.random() > skipFileProb) continue;
+
+            const openFileAbsolutePath = path.join(testDirPlaceholder, openFileRelativePath).replace(/\\/g, "/");
+
+            if (openFileAbsolutePaths.length == 5) {
+                const closedFileAbsolutePath = openFileAbsolutePaths.shift();
+                // This could be combined with the next updateOpen, but it's easier to simplify the repro if they're separate
+                await message({
+                    "command": "updateOpen",
+                    "arguments": {
+                        "changedFiles": [],
+                        "closedFiles": [closedFileAbsolutePath],
+                        "openFiles": []
+                    }
+                });
+            }
+
+            openFileAbsolutePaths.push(openFileAbsolutePath);
+
+            const openFileContents = await fs.promises.readFile(openFileRelativePath, { encoding: "utf-8" });
+            await message({
+                "command": "updateOpen",
+                "arguments": {
+                    "changedFiles": [],
+                    "closedFiles": [],
+                    "openFiles": [
+                        {
+                            "file": openFileAbsolutePath,
+                            "fileContent": openFileContents,
+                            "projectRootPath": testDirPlaceholder,
+                        }
+                    ]
+                }
+            });
+
+            const triggerChars = [".", '"', "'", "`", "/", "@", "<", "#", " "];
+
+            let line = 1;
+            let column = 1;
+
+            let prev = "";
+
+            await message({
+                "command": "organizeImports",
+                "arguments": {
+                    "scope": {
+                        "type": "file",
+                        "args": {
+                            "file": openFileAbsolutePath
+                        }
+                    },
+                    "skipDestructiveCodeActions": true
+                }
+            }, 0.5);
+
+            await message({
+                "command": "organizeImports",
+                "arguments": {
+                    "scope": {
+                        "type": "file",
+                        "args": {
+                            "file": openFileAbsolutePath
+                        }
+                    },
+                    "skipDestructiveCodeActions": false
+                }
+            }, 0.5);
+
+            if (openFileContents.length < 1e6) {
+                await message({
+                    "command": "getOutliningSpans",
+                    "arguments": {
+                        "file": openFileAbsolutePath
+                    }
+                }, 0.9);
+            }
+
+            if (loadedNewProject) {
+                loadedNewProject = false;
+
+                const navtoResponse = await message({
+                    "command": "navto",
+                    "arguments": {
+                        "searchValue": "a",
+                        "maxResultCount": 256
+                    }
+                }, 0.5);
+
+                const navtoEntry = navtoResponse?.body.find((x: any) => x.name.length > 4);
+                if (navtoEntry) {
+                    await message({
+                        "command": "navto",
+                        "arguments": {
+                            "searchValue": navtoEntry.name.substr(0, 3),
+                            "maxResultCount": 256
+                        }
+                    });
+                }
+            }
+
+            for (let i = 0; i < openFileContents.length; i++) {
+                const curr = openFileContents[i];
+                const next = openFileContents[i + 1];
+
+                // Increase probabilities around things that look like jsdoc, where we've had problems in the past
+                const isAt = curr === "@";
+
+                // Note that this only catches Latin letters - we'll test within tokens of non-Latin characters
+                if (!(/\w/.test(prev) && /\w/.test(curr)) && !(/[ \t]/.test(prev) && /[ \t]/.test(curr))) {
+                    await message({
+                        "command": "definitionAndBoundSpan",
+                        "arguments": {
+                            "file": openFileAbsolutePath,
+                            "line": line,
+                            "offset": column,
+                        }
+                    }, isAt ? 0.5 : 0.001);
+
+                    await message({
+                        "command": "references",
+                        "arguments": {
+                            "file": openFileAbsolutePath,
+                            "line": line,
+                            "offset": column,
+                        }
+                    }, isAt ? 0.5 : 0.00005);
+
+                    const invokedResponse = await message({
+                        "command": "completionInfo",
+                        "arguments": {
+                            "file": openFileAbsolutePath,
+                            "line": line,
+                            "offset": column,
+                            "includeExternalModuleExports": Math.random() < 0.01, // auto-imports are too slow to test everywhere
+                            "includeInsertTextCompletions": true,
+                            "triggerKind": 1,
+                        }
+                    }, isAt ? 0.5 : 0.001);
+
+                    if (invokedResponse?.body && invokedResponse.body.entries.length > 0) {
+                        await message({
+                            "command": "completionEntryDetails",
+                            "arguments": {
+                                "file": openFileAbsolutePath,
+                                "line": line,
+                                "offset": column,
+                                "entryNames": [
+                                    invokedResponse.body.entries[0].name,
+                                ],
+                            }
+                        });
+                    }
+
+                    const triggerCharIndex = triggerChars.indexOf(curr);
+                    if (triggerCharIndex >= 0 && /\w/.test(prev)) {
+                        await message({
+                            "command": "completionInfo",
+                            "arguments": {
+                                "file": openFileAbsolutePath,
+                                "line": line,
+                                "offset": column,
+                                "includeExternalModuleExports": false,
+                                "includeInsertTextCompletions": true,
+                                "triggerKind": 2,
+                                "triggerCharacter": triggerChars[triggerCharIndex],
+                            }
+                        }, 0.005);
+                    }
+                }
+
+                if (curr === "\r" || curr === "\n") {
+                    if (line == 1) {
+                        // Note that this does not modify openFileContents, so it does not update `i`
+                        await message({
+                            "command": "updateOpen",
+                            "arguments": {
+                                "changedFiles": [
+                                    {
+                                        "fileName": openFileAbsolutePath,
+                                        "textChanges": [
+                                            {
+                                                "newText": " //comment",
+                                                "start": {
+                                                    "line": line,
+                                                    "offset": column,
+                                                },
+                                                "end": {
+                                                    "line": line,
+                                                    "offset": column,
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "closedFiles": [],
+                                "openFiles": [],
+                            }
+                        }, 0.5);
+                    }
+
+                    line++;
+                    column = 1;
+                    if (curr === "\r" && next === "\n") {
+                        i++;
+                    }
+                }
+                else {
+                    column++;
+                }
+
+                prev = curr;
+            }
+        }
+
+        console.error("Shutting down server");
+        // Will throw if the server has crashed and `exitResult` will be considered below
+        exitExpected = true;
+        if (!await server.exitOrKill(exitTimeoutMs)) {
+            console.log(`Server didn't exit within ${exitTimeoutMs} ms and had to be killed`);
+            process.exit(EXIT_SERVER_EXIT_FAILED);
+        }
+    } catch (e) {
+        console.error("Killing server after unhandled exception");
+        console.error(e);
+
+        exitExpected = true;
+        server.kill();
+        process.exit(EXIT_UNHANDLED_EXCEPTION);
+    }
+
+    async function message(request: any, prob = 1) {
+        if (Math.random() > prob) return undefined;
+
+        request = {
+            "seq": seq++,
+            "type": "request",
+            ...request,
+        };
+
+        const openFileContents = [];
+        if (request.command === "updateOpen" || request.command === "applyChangedToOpenFiles") {
+            for (const openFile of request.arguments.openFiles) {
+                openFileContents.push(openFile.fileContent ?? openFile.content);
+                delete openFile.fileContent;
+                delete openFile.content;
+            }
+        }
+
+        const replayString = JSON.stringify(request) + "\n";
+        await replayScriptHandle.write(replayString);
+
+        for (let i = 0; i < openFileContents.length; i++) {
+            const propName = request.command === "updateOpen" ? "fileContent" : "content";
+            request.arguments.openFiles[i][propName] = openFileContents[i];
+        }
+
+        const requestString = JSON.stringify(request).replace(new RegExp(testDirPlaceholder, "g"), testDir);
+
+        const start = performance.now();
+        const response = await server.message(JSON.parse(requestString));
+        const end = performance.now();
+        requestTimes[request.command] = (requestTimes[request.command] ?? 0) + (end - start);
+        requestCounts[request.command] = (requestCounts[request.command] ?? 0) + 1;
+
+        if (response && !response.success && response.message !== "No content available.") {
+            const errorMessage = response.message ?? "Unknown error";
+            if (diagnosticOutput) {
+                console.error(`Request failed:
+${JSON.stringify(request, undefined, 2)}
+${JSON.stringify(response, undefined, 2)}`);
+            }
+            else {
+                console.error(errorMessage);
+            }
+            console.log(JSON.stringify(response));
+
+            exitExpected = true;
+            server.kill();
+            process.exit(EXIT_SERVER_ERROR);
+        }
+
+        return response;
+    }
+}

--- a/src/utils/exerciseServerConstants.ts
+++ b/src/utils/exerciseServerConstants.ts
@@ -1,0 +1,6 @@
+export const EXIT_BAD_ARGS = 1;
+export const EXIT_UNHANDLED_EXCEPTION = 2;
+export const EXIT_SERVER_EXIT_FAILED = 3;
+export const EXIT_SERVER_CRASH = 4; // The server process actually exited
+export const EXIT_SERVER_ERROR = 5; // The server process sent an error response
+export const EXIT_LANGUAGE_SERVICE_DISABLED = 6;

--- a/src/utils/installPackages.ts
+++ b/src/utils/installPackages.ts
@@ -22,7 +22,7 @@ export interface InstallCommand {
  * Traverses the given directory and returns a list of commands that can be used, in order, to install
  * the packages required for building.
  */
-export async function installPackages(repoDir: string, ignoreScripts: boolean, quietOutput: boolean, recursiveSearch: boolean, lernaPackages?: readonly string[], types?: string[]): Promise<readonly InstallCommand[]> {
+export async function installPackages(repoDir: string, ignoreScripts: boolean, quietOutput: boolean, recursiveSearch: boolean, lernaPackages?: readonly string[], types?: string[]): Promise<InstallCommand[]> {
     lernaPackages = lernaPackages ?? await utils.getLernaOrder(repoDir);
 
     const isRepoYarn = await utils.exists(path.join(repoDir, "yarn.lock"));

--- a/test/getTscErrors.test.ts
+++ b/test/getTscErrors.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync } from "fs"
 import * as path from 'path'
 import { buildAndGetErrors } from '../src/utils/getTscErrors'
-import { downloadTypescriptRepoAsync } from '../src/main'
+import { downloadTsRepoAsync } from '../src/main'
 describe("getErrors", () => {
     jest.setTimeout(10 * 60 * 1000)
 
@@ -10,7 +10,7 @@ describe("getErrors", () => {
             if (!existsSync("./testDownloads/getErrors")) {
                 mkdirSync("./testDownloads/getErrors", { recursive: true });
             }
-            await downloadTypescriptRepoAsync('./testDownloads/getErrors', 'https://github.com/sandersn/typescript', 'test-fake-error');
+            await downloadTsRepoAsync('./testDownloads/getErrors', 'https://github.com/sandersn/typescript', 'test-fake-error', 'tsc');
         }
     });
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,12 +1,12 @@
 /// <reference types="jest" />
-import { getRepoResult, downloadTypescriptRepoAsync } from '../src/main'
+import { getTscRepoResult, downloadTsRepoAsync } from '../src/main'
 import { execSync } from "child_process"
 import { existsSync, mkdirSync } from "fs"
 import path = require("path")
 describe("main", () => {
     jest.setTimeout(10 * 60 * 1000)
     xit("build-only correctly caches", async () => {
-        const { status, summary } = await getRepoResult(
+        const { status, summary } = await getTscRepoResult(
             {
                 name: "TypeScript-Node-Starter",
                 url: "https://github.com/Microsoft/TypeScript-Node-Starter.git"
@@ -16,7 +16,6 @@ describe("main", () => {
             path.resolve("./typescript-44585/built/local/tsc.js"),
             /*ignoreOldTscFailures*/ true, // as in a user test
             "./ts_downloads",
-            /*isDownloadDirOnTmpFs*/ false,
             /*diagnosticOutput*/ false)
         expect(status).toEqual("NewBuildHadErrors")
         expect(summary).toBeDefined()
@@ -30,6 +29,6 @@ describe("main", () => {
         else if (existsSync("./testDownloads/main/typescript-test-fake-error")) {
             execSync("cd ./testDownloads/main/typescript-test-fake-error && git restore . && cd ..")
         }
-        await downloadTypescriptRepoAsync('./testDownloads/main', 'https://github.com/sandersn/typescript', 'test-fake-error')
+        await downloadTsRepoAsync('./testDownloads/main', 'https://github.com/sandersn/typescript', 'test-fake-error', 'tsc')
     })
 })


### PR DESCRIPTION
For a core set of protocol requests, statistically sample locations in the projects under test and report error responses or server crashes.

TODO: The AzDO pipelines will need to be restructured to make these variant runs schedulable.
TODO: The PR variant of these tests needs to be smarter about baselining (e.g. not report errors that pre-date the PR).