### PR TITLE
Add new pipelines for scheduled tsserver TS and JS runs

### DIFF
--- a/azure-pipelines-gitTests-template.yml
+++ b/azure-pipelines-gitTests-template.yml
@@ -1,0 +1,93 @@
+parameters:
+  - name: POST_RESULT
+    displayName: Post GitHub issue with results
+    type: boolean
+    default: true
+  - name: DIAGNOSTIC_OUTPUT
+    displayName: Log diagnostic data
+    type: boolean
+    default: false
+  - name: REPO_COUNT
+    displayName: Repo Count
+    type: number
+    default: 200
+  - name: REPO_START_INDEX
+    displayName: Repo Start Index
+    type: number
+    default: 0
+  - name: OLD_VERSION
+    displayName: Baseline TypeScript package version
+    type: string
+    default: latest
+  - name: NEW_VERSION
+    displayName: Candidate TypeScript package version
+    type: string
+    default: next
+  - name: MACHINE_COUNT
+    displayName: Machine Count
+    type: number
+    default: 4
+  - name: ENTRYPOINT
+    displayName: TypeScript entrypoint
+    type: string
+  - name: LANGUAGE
+    displayName: Language of repos on GitHub (tsserver only)
+    type: string
+
+jobs:
+- job: ListRepos
+  steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '16.x'
+    displayName: 'Install Node.js'
+  - script: |
+      npm ci
+      npm run build
+      mkdir artifacts
+      node dist/listTopRepos ${{ parameters.LANGUAGE }} ${{ parameters.REPO_COUNT }} ${{ parameters.REPO_START_INDEX }} artifacts/repos.json
+    displayName: 'List top TS repos'
+    env:
+      GITHUB_PAT: $(GITHUB_PAT)
+  - publish: artifacts
+    artifact: RepoList
+- job: DetectNewErrors
+  dependsOn: ListRepos
+  continueOnError: true
+  timeoutInMinutes: 360
+  strategy:
+    parallel: ${{ parameters.MACHINE_COUNT }}
+  steps:
+  - download: current
+    artifact: RepoList
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '16.x'
+    displayName: 'Install Node.js'
+  - script: |
+      npm ci
+      npm run build
+      npm install -g pnpm
+      mkdir 'RepoResults$(System.JobPositionInPhase)'
+      node dist/checkGithubRepos ${{ parameters.ENTRYPOINT }} ${{ parameters.OLD_VERSION }} ${{ parameters.NEW_VERSION }} '$(Pipeline.Workspace)/RepoList/repos.json' $(System.TotalJobsInPhase) $(System.JobPositionInPhase) 'RepoResults$(System.JobPositionInPhase)' ${{ parameters.DIAGNOSTIC_OUTPUT }}
+    displayName: 'Run TypeScript on repos'
+    continueOnError: true
+    env:
+      GITHUB_PAT: $(GITHUB_PAT)
+  - publish: 'RepoResults$(System.JobPositionInPhase)'
+    artifact: 'RepoResults$(System.JobPositionInPhase)'
+- job: ReportNewErrors
+  dependsOn: DetectNewErrors
+  steps:
+  - download: current
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '16.x'
+    displayName: 'Install Node.js'
+  - script: |
+      npm ci
+      npm run build
+      node dist/postGithubIssue ${{ parameters.ENTRYPOINT }} ${{ parameters.LANGUAGE }} ${{ parameters.REPO_COUNT }} ${{ parameters.REPO_START_INDEX }} '$(Pipeline.Workspace)' '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)' '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=artifacts&type=publishedArtifacts' ${{ parameters.POST_RESULT }}
+    displayName: 'Create issue from new errors'
+    env:
+      GITHUB_PAT: $(GITHUB_PAT)

--- a/azure-pipelines-gitTests-tsserver-js.yml
+++ b/azure-pipelines-gitTests-tsserver-js.yml
@@ -1,0 +1,19 @@
+schedules:
+  - cron: "0 20 * * Sun" # time is in UTC
+    displayName: Sunday overnight run
+    always: true
+    branches:
+      include:
+        - main
+
+pr: none
+trigger: none
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+extends:
+  template: azure-pipelines-gitTests-template.yml
+  parameters:
+    ENTRYPOINT: tsserver
+    LANGUAGE: JAVASCRIPT

--- a/azure-pipelines-gitTests-tsserver-ts.yml
+++ b/azure-pipelines-gitTests-tsserver-ts.yml
@@ -1,0 +1,19 @@
+schedules:
+  - cron: "0 19 * * Sun" # time is in UTC
+    displayName: Sunday overnight run
+    always: true
+    branches:
+      include:
+        - main
+
+pr: none
+trigger: none
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+extends:
+  template: azure-pipelines-gitTests-template.yml
+  parameters:
+    ENTRYPOINT: tsserver
+    LANGUAGE: TypeScript

--- a/azure-pipelines-gitTests.yml
+++ b/azure-pipelines-gitTests.yml
@@ -39,6 +39,13 @@ parameters:
     values:
     - tsc
     - tsserver
+  - name: LANGUAGE
+    displayName: Language of repos on GitHub (tsserver only)
+    type: string
+    default: TypeScript
+    values:
+    - TypeScript
+    - JavaScript
 
 schedules:
   - cron: "0 18 * * Sun" # time is in UTC
@@ -54,60 +61,15 @@ trigger: none
 pool:
   vmImage: 'ubuntu-latest'
 
-jobs:
-- job: ListRepos
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '16.x'
-    displayName: 'Install Node.js'
-  - script: |
-      npm ci
-      npm run build
-      mkdir artifacts
-      node dist/listTopRepos TypeScript ${{ parameters.REPO_COUNT }} ${{ parameters.REPO_START_INDEX }} artifacts/repos.json
-    displayName: 'List top TS repos'
-    env:
-      GITHUB_PAT: $(GITHUB_PAT)
-  - publish: artifacts
-    artifact: RepoList
-- job: DetectNewErrors
-  dependsOn: ListRepos
-  continueOnError: true
-  timeoutInMinutes: 360
-  strategy:
-    parallel: ${{ parameters.MACHINE_COUNT }}
-  steps:
-  - download: current
-    artifact: RepoList
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '16.x'
-    displayName: 'Install Node.js'
-  - script: |
-      npm ci
-      npm run build
-      npm install -g pnpm
-      mkdir 'RepoResults$(System.JobPositionInPhase)'
-      node dist/checkGithubRepos ${{ parameters.ENTRYPOINT }} ${{ parameters.OLD_VERSION }} ${{ parameters.NEW_VERSION }} '$(Pipeline.Workspace)/RepoList/repos.json' $(System.TotalJobsInPhase) $(System.JobPositionInPhase) 'RepoResults$(System.JobPositionInPhase)' ${{ parameters.DIAGNOSTIC_OUTPUT }}
-    displayName: 'Run TypeScript on repos'
-    continueOnError: true
-    env:
-      GITHUB_PAT: $(GITHUB_PAT)
-  - publish: 'RepoResults$(System.JobPositionInPhase)'
-    artifact: 'RepoResults$(System.JobPositionInPhase)'
-- job: ReportNewErrors
-  dependsOn: DetectNewErrors
-  steps:
-  - download: current
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '16.x'
-    displayName: 'Install Node.js'
-  - script: |
-      npm ci
-      npm run build
-      node dist/postGithubIssue ${{ parameters.ENTRYPOINT }} ${{ parameters.REPO_COUNT }} ${{ parameters.REPO_START_INDEX }} '$(Pipeline.Workspace)' '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)' '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=artifacts&type=publishedArtifacts' ${{ parameters.POST_RESULT }}
-    displayName: 'Create issue from new errors'
-    env:
-      GITHUB_PAT: $(GITHUB_PAT)
+extends:
+  template: azure-pipelines-gitTests-template.yml
+  parameters:
+    POST_RESULT: ${{ parameters.POST_RESULT }}
+    DIAGNOSTIC_OUTPUT: ${{ parameters.DIAGNOSTIC_OUTPUT }}
+    REPO_COUNT: ${{ parameters.REPO_COUNT }}
+    REPO_START_INDEX: ${{ parameters.REPO_START_INDEX }}
+    OLD_VERSION: ${{ parameters.OLD_VERSION }}
+    NEW_VERSION: ${{ parameters.NEW_VERSION }}
+    MACHINE_COUNT: ${{ parameters.MACHINE_COUNT }}
+    ENTRYPOINT: ${{ parameters.ENTRYPOINT }}
+    LANGUAGE: ${{ parameters.LANGUAGE }}

--- a/src/postGithubIssue.ts
+++ b/src/postGithubIssue.ts
@@ -6,12 +6,12 @@ import pu = require("./utils/packageUtils");
 
 const { argv } = process;
 
-if (argv.length !== 9) {
-    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <ts_entrypoint> <repo_count> <repo_start_index> <result_dir_path> <log_uri> <artifacts_uri> <post_result>`);
+if (argv.length !== 10) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <ts_entrypoint> <language> <repo_count> <repo_start_index> <result_dir_path> <log_uri> <artifacts_uri> <post_result>`);
     process.exit(-1);
 }
 
-const [, , ep, repoCount, repoStartIndex, resultDirPath, logUri, artifactsUri, post] = argv;
+const [, , ep, language, repoCount, repoStartIndex, resultDirPath, logUri, artifactsUri, post] = argv;
 const postResult = post.toLowerCase() === "true";
 const entrypoint = ep as TsEntrypoint;
 
@@ -45,7 +45,7 @@ for (const path of metadataFilePaths) {
 }
 
 const title = entrypoint === "tsserver"
-    ? `[ServerErrors] ${newTscResolvedVersion}`
+    ? `[ServerErrors][${language}] ${newTscResolvedVersion}`
     : `[NewErrors] ${newTscResolvedVersion} vs ${oldTscResolvedVersion}`;
 const description = entrypoint === "tsserver"
     ? `The following errors were reported by ${newTscResolvedVersion}`


### PR DESCRIPTION
A pipeline schedule can only use the default parameter values so, while azure-pipelines-gitTests.yml can be used to kick off any of these runs _manually_, it cannot be used to schedule runs other than the default.

Unfortunately, there does not appear to be a way to avoid duplicating the parameter list between the template and the pipeline used to kick off manual runs.