### PR TITLE
Add basic support for yarn and pnpm workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "@typescript/server-harness": "^0.3.4",
                 "@typescript/server-replay": "^0.2.11",
                 "glob": "^7.2.3",
+                "js-yaml": "^4.1.0",
                 "json5": "^2.2.1",
                 "random-seed": "^0.3.0",
                 "simple-git": "^3.10.0"
@@ -21,6 +22,7 @@
             "devDependencies": {
                 "@types/glob": "^7.2.0",
                 "@types/jest": "^27.5.2",
+                "@types/js-yaml": "^4.0.5",
                 "@types/node": "^14.18.21",
                 "@types/random-seed": "^0.3.3",
                 "jest": "^27.4.4",
@@ -595,6 +597,28 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@istanbuljs/schema": {
@@ -1222,6 +1246,12 @@
                 "pretty-format": "^27.0.0"
             }
         },
+        "node_modules/@types/js-yaml": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+            "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+            "dev": true
+        },
         "node_modules/@types/minimatch": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -1400,13 +1430,9 @@
             }
         },
         "node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -3120,13 +3146,11 @@
             "dev": true
         },
         "node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-            "dev": true,
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "^2.0.1"
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
@@ -5110,6 +5134,27 @@
                 "get-package-type": "^0.1.0",
                 "js-yaml": "^3.13.1",
                 "resolve-from": "^5.0.0"
+            },
+            "dependencies": {
+                "argparse": {
+                    "version": "1.0.10",
+                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+                    "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+                    "dev": true,
+                    "requires": {
+                        "sprintf-js": "~1.0.2"
+                    }
+                },
+                "js-yaml": {
+                    "version": "3.14.1",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+                    "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
+                    }
+                }
             }
         },
         "@istanbuljs/schema": {
@@ -5685,6 +5730,12 @@
                 "pretty-format": "^27.0.0"
             }
         },
+        "@types/js-yaml": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+            "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+            "dev": true
+        },
         "@types/minimatch": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -5826,13 +5877,9 @@
             }
         },
         "argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "requires": {
-                "sprintf-js": "~1.0.2"
-            }
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "asynckit": {
             "version": "0.4.0",
@@ -7144,13 +7191,11 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-            "dev": true,
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "^2.0.1"
             }
         },
         "jsdom": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "@typescript/server-harness": "^0.3.4",
         "@typescript/server-replay": "^0.2.11",
         "glob": "^7.2.3",
+        "js-yaml": "^4.1.0",
         "json5": "^2.2.1",
         "random-seed": "^0.3.0",
         "simple-git": "^3.10.0"
@@ -23,6 +24,7 @@
     "devDependencies": {
         "@types/glob": "^7.2.0",
         "@types/jest": "^27.5.2",
+        "@types/js-yaml": "^4.0.5",
         "@types/node": "^14.18.21",
         "@types/random-seed": "^0.3.3",
         "jest": "^27.4.4",

--- a/src/main.ts
+++ b/src/main.ts
@@ -139,7 +139,7 @@ async function installPackagesAndGetCommands(
                 /*ignoreScripts*/ true,
                 /*quietOutput*/ !diagnosticOutput,
                 /*recursiveSearch*/ !isUserTestRepo,
-                /*lernaPackages*/ undefined,
+                /*monorepoPackages*/ undefined,
             repo.types);
         await installPackages(repoDir, commands, packageTimeout);
         return commands;

--- a/src/utils/getTscErrors.ts
+++ b/src/utils/getTscErrors.ts
@@ -64,7 +64,7 @@ export function errorEquals(error1: Error, error2: Error) {
  * @param tscPath The path to tsc.js.
  * @param skipLibCheck True pass --skipLibCheck when building non-composite projects.  (Defaults to true)
  */
-export async function buildAndGetErrors(repoDir: string, isUserTestRepo: boolean, tscPath: string, timeoutMs: number, skipLibCheck: boolean = true): Promise<RepoErrors> {
+export async function buildAndGetErrors(repoDir: string, monorepoPackages: readonly string[], isUserTestRepo: boolean, tscPath: string, timeoutMs: number, skipLibCheck: boolean = true): Promise<RepoErrors> {
     const projectErrors: ProjectErrors[] = [];
 
     // If it's a user test repo and there's a build.sh in the root, don't bother searching for projects
@@ -95,7 +95,7 @@ export async function buildAndGetErrors(repoDir: string, isUserTestRepo: boolean
     const simpleBuildArgs = ["--skipLibCheck", `${skipLibCheck}`, "--incremental", "false", "--pretty", "false", "-p"];
     const compositeBuildArgs = ["-b", "-f", "-v"]; // Build mode doesn't support --skipLibCheck or --pretty
 
-    const { simpleProjects, rootCompositeProjects, hasError: hasConfigFailure } = await projectGraph.getProjectsToBuild(repoDir);
+    const { simpleProjects, rootCompositeProjects, hasError: hasConfigFailure } = await projectGraph.getProjectsToBuild(repoDir, monorepoPackages);
     // TODO: Move this inside getProjectsToBuild, separating them is pointless (originally separate to enable simple-only and composite-only runs)
     const projectsToBuild = simpleProjects.concat(rootCompositeProjects);
     if (!projectsToBuild.length) {

--- a/src/utils/installPackages.ts
+++ b/src/utils/installPackages.ts
@@ -22,8 +22,8 @@ export interface InstallCommand {
  * Traverses the given directory and returns a list of commands that can be used, in order, to install
  * the packages required for building.
  */
-export async function installPackages(repoDir: string, ignoreScripts: boolean, quietOutput: boolean, recursiveSearch: boolean, lernaPackages?: readonly string[], types?: string[]): Promise<InstallCommand[]> {
-    lernaPackages = lernaPackages ?? await utils.getLernaOrder(repoDir);
+export async function installPackages(repoDir: string, ignoreScripts: boolean, quietOutput: boolean, recursiveSearch: boolean, monorepoPackages?: readonly string[], types?: string[]): Promise<InstallCommand[]> {
+    monorepoPackages = monorepoPackages ?? await utils.getMonorepoOrder(repoDir);
 
     const isRepoYarn = await utils.exists(path.join(repoDir, "yarn.lock"));
     // The existence of .yarnrc.yml indicates that this repo uses yarn 2
@@ -36,12 +36,12 @@ export async function installPackages(repoDir: string, ignoreScripts: boolean, q
     const packageFiles = utils.glob(repoDir, globPattern);
 
     for (const packageFile of packageFiles) {
-        let inLernaPackageDir = false;
-        for (const lernaPackage of lernaPackages) {
-            if (inLernaPackageDir = packageFile.startsWith(lernaPackage)) break;
+        let inMonorepoPackageDir = false;
+        for (const monorepoPackage of monorepoPackages) {
+            if (inMonorepoPackageDir = packageFile.startsWith(monorepoPackage)) break;
         }
-        if (inLernaPackageDir) {
-            // Skipping installation of lerna package
+        if (inMonorepoPackageDir) {
+            // Skipping installation of monorepo package
             continue;
         }
 

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -53,7 +53,9 @@ export async function getMonorepoOrder(repoDir: string): Promise<readonly string
                 }
             }
         }
-        return yarnWorkspaceOrder;
+        if (yarnWorkspaceOrder.length) {
+            return yarnWorkspaceOrder;
+        }
     }
 
     const pnpmWorkspaceFiles = glob(repoDir, "**/pnpm-workspace.yaml");
@@ -61,8 +63,8 @@ export async function getMonorepoOrder(repoDir: string): Promise<readonly string
         const pnpmWorkspaceOrder: string[] = [];
         for (const pnpmWorkspaceFile of pnpmWorkspaceFiles) {
             const contents = await fs.promises.readFile(pnpmWorkspaceFile, { encoding: "utf-8" });
-            const config = yaml.load(contents) as { packages?: string[] };
-            const workspaceDirs = config.packages;
+            const config = yaml.load(contents) as { packages?: string[] } | undefined; // undefined for an empty test fixture
+            const workspaceDirs = config?.packages;
             if (workspaceDirs) {
                 const pnpmDir = path.dirname(pnpmWorkspaceFile);
                 for (const workspaceDir of workspaceDirs) {
@@ -74,7 +76,9 @@ export async function getMonorepoOrder(repoDir: string): Promise<readonly string
                 }
             }
         }
-        return pnpmWorkspaceOrder;
+        if (pnpmWorkspaceOrder.length) {
+            return pnpmWorkspaceOrder;
+        }
     }
 
     const lernaFiles = glob(repoDir, "**/lerna.json");
@@ -87,7 +91,9 @@ export async function getMonorepoOrder(repoDir: string): Promise<readonly string
                 await appendOrderedMonorepoPackages(pkgPaths, lernaOrder);
             }
         }
-        return lernaOrder;
+        if (lernaOrder.length) {
+            return lernaOrder;
+        }
     }
 
     return [];

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -120,34 +120,27 @@ async function appendOrderedMonorepoPackages(pkgPaths: string[], monorepoOrder: 
 
         if (pkg.dependencies) {
             for (const dep in pkg.dependencies) {
-                const depPkg = pkgMap[stripWorkspaceProtocol(dep)];
+                const depPkg = pkgMap[dep];
                 if (depPkg) visit(depPkg);
             }
         }
 
         if (pkg.devDependencies) {
             for (const dep in pkg.devDependencies) {
-                const depPkg = pkgMap[stripWorkspaceProtocol(dep)];
+                const depPkg = pkgMap[dep];
                 if (depPkg) visit(depPkg);
             }
         }
 
         if (pkg.peerDependencies) {
             for (const dep in pkg.peerDependencies) {
-                const depPkg = pkgMap[stripWorkspaceProtocol(dep)];
+                const depPkg = pkgMap[dep];
                 if (depPkg) visit(depPkg);
             }
         }
 
         pkg.meta_state = "visited";
         monorepoOrder.push(pkg.meta_dir);
-
-        function stripWorkspaceProtocol(name: string): string {
-            const protocolPrefix = "workspace:";
-            return name.startsWith(protocolPrefix)
-                ? name.substring(protocolPrefix.length)
-                : name;
-        }
     }
 }
 

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -8,7 +8,7 @@ interface Package {
     meta_dir: string,
     meta_state: "unvisited" | "visiting" | "visited",
     name: string,
-    workspaces?: /*readonly*/ string[] | { packages: readonly string[] }, // readonly messes up narrowing
+    workspaces?: readonly string[] | { packages: readonly string[] },
     dependencies?: readonly string[],
     devDependencies?: readonly string[],
     peerDependencies?: readonly string[],
@@ -44,7 +44,7 @@ export async function getMonorepoOrder(repoDir: string): Promise<readonly string
                 const pkg: Package = json5.parse(contents);
                 const workspaces = pkg.workspaces;
                 if (workspaces) {
-                    const workspaceDirs = Array.isArray(workspaces) ? workspaces : workspaces.packages;
+                    const workspaceDirs = "packages" in workspaces ? workspaces.packages : workspaces;
                     for (const workspaceDir of workspaceDirs) {
                         // workspaceDir might end with `/*` - glob will do the right thing
                         const pkgPaths = glob(yarnDir, path.join(workspaceDir, "package.json"));

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -27,11 +27,11 @@ export async function exists(path: string): Promise<boolean> {
 }
 
 /**
- * Heuristically returns a list of package.json paths in lerna dependency order.
+ * Heuristically returns a list of package.json paths in monorepo dependency order.
  * NB: Does not actually consume lerna.json.
  */
-export async function getLernaOrder(repoDir: string): Promise<readonly string[]> {
-    const lernaOrder: string[] = [];
+export async function getMonorepoOrder(repoDir: string): Promise<readonly string[]> {
+    const monorepoOrder: string[] = [];
     const lernaFiles = glob(repoDir, "**/lerna.json");
     for (const lernaFile of lernaFiles) {
         const lernaDir = path.dirname(lernaFile);
@@ -77,10 +77,10 @@ export async function getLernaOrder(repoDir: string): Promise<readonly string[]>
                 }
 
                 pkg.meta_state = "visited";
-                lernaOrder.push(pkg.meta_dir);
+                monorepoOrder.push(pkg.meta_dir);
             }
         }
     }
 
-    return lernaOrder;
+    return monorepoOrder;
 }

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -37,50 +37,54 @@ export async function getMonorepoOrder(repoDir: string): Promise<readonly string
         const lernaDir = path.dirname(lernaFile);
         if (await exists(path.join(lernaDir, "packages"))) {
             const pkgPaths = glob(path.join(lernaDir, "packages"), "**/package.json");
-            const pkgs = await Promise.all(pkgPaths.map(async pkgPath => {
-                const contents = await fs.promises.readFile(pkgPath, { encoding: "utf-8" });
-                const pkg: Package = json5.parse(contents);
-                pkg.meta_dir = path.dirname(pkgPath);
-                pkg.meta_state = "unvisited";
-                return pkg;
-            }));
-            const pkgMap: Record<string, Package | undefined> = {};
-            for (const pkg of pkgs) {
-                pkgMap[pkg.name] = pkg;
-            }
-
-            while (true) {
-                const pkg = pkgs.find(p => p.meta_state === "unvisited");
-                if (!pkg) break;
-                visit(pkg);
-            }
-
-            function visit(pkg: Package): void {
-                // "visiting" indicates a cycle, which lerna allows
-                if (pkg.meta_state !== "unvisited") return;
-
-                pkg.meta_state = "visiting";
-
-                for (const dep in pkg.dependencies) {
-                    const depPkg = pkgMap[dep];
-                    if (depPkg) visit(depPkg);
-                }
-
-                for (const dep in pkg.devDependencies) {
-                    const depPkg = pkgMap[dep];
-                    if (depPkg) visit(depPkg);
-                }
-
-                for (const dep in pkg.peerDependencies) {
-                    const depPkg = pkgMap[dep];
-                    if (depPkg) visit(depPkg);
-                }
-
-                pkg.meta_state = "visited";
-                monorepoOrder.push(pkg.meta_dir);
-            }
+            await getMonorepoOrderWorker(pkgPaths, monorepoOrder);
         }
     }
 
     return monorepoOrder;
 }
+async function getMonorepoOrderWorker(pkgPaths: string[], monorepoOrder: string[]) {
+    const pkgs = await Promise.all(pkgPaths.map(async (pkgPath) => {
+        const contents = await fs.promises.readFile(pkgPath, { encoding: "utf-8" });
+        const pkg: Package = json5.parse(contents);
+        pkg.meta_dir = path.dirname(pkgPath);
+        pkg.meta_state = "unvisited";
+        return pkg;
+    }));
+    const pkgMap: Record<string, Package | undefined> = {};
+    for (const pkg of pkgs) {
+        pkgMap[pkg.name] = pkg;
+    }
+
+    while (true) {
+        const pkg = pkgs.find(p => p.meta_state === "unvisited");
+        if (!pkg) break;
+        visit(pkg);
+    }
+
+    function visit(pkg: Package): void {
+        // "visiting" indicates a cycle, which some monorepo systems (e.g. lerna) allow
+        if (pkg.meta_state !== "unvisited") return;
+
+        pkg.meta_state = "visiting";
+
+        for (const dep in pkg.dependencies) {
+            const depPkg = pkgMap[dep];
+            if (depPkg) visit(depPkg);
+        }
+
+        for (const dep in pkg.devDependencies) {
+            const depPkg = pkgMap[dep];
+            if (depPkg) visit(depPkg);
+        }
+
+        for (const dep in pkg.peerDependencies) {
+            const depPkg = pkgMap[dep];
+            if (depPkg) visit(depPkg);
+        }
+
+        pkg.meta_state = "visited";
+        monorepoOrder.push(pkg.meta_dir);
+    }
+}
+

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -33,19 +33,6 @@ export async function exists(path: string): Promise<boolean> {
  * NB: Does not actually consume lerna.json.
  */
 export async function getMonorepoOrder(repoDir: string): Promise<readonly string[]> {
-    const lernaFiles = glob(repoDir, "**/lerna.json");
-    if (lernaFiles.length) {
-        const lernaOrder: string[] = [];
-        for (const lernaFile of lernaFiles) {
-            const lernaDir = path.dirname(lernaFile);
-            if (await exists(path.join(lernaDir, "packages"))) {
-                const pkgPaths = glob(path.join(lernaDir, "packages"), "**/package.json");
-                await appendOrderedMonorepoPackages(pkgPaths, lernaOrder);
-            }
-        }
-        return lernaOrder;
-    }
-
     const yarnLockFiles = glob(repoDir, "**/yarn.lock");
     if (yarnLockFiles.length) {
         const yarnWorkspaceOrder: string[] = [];
@@ -87,6 +74,19 @@ export async function getMonorepoOrder(repoDir: string): Promise<readonly string
             }
         }
         return pnpmWorkspaceOrder;
+    }
+
+    const lernaFiles = glob(repoDir, "**/lerna.json");
+    if (lernaFiles.length) {
+        const lernaOrder: string[] = [];
+        for (const lernaFile of lernaFiles) {
+            const lernaDir = path.dirname(lernaFile);
+            if (await exists(path.join(lernaDir, "packages"))) {
+                const pkgPaths = glob(path.join(lernaDir, "packages"), "**/package.json");
+                await appendOrderedMonorepoPackages(pkgPaths, lernaOrder);
+            }
+        }
+        return lernaOrder;
     }
 
     return [];

--- a/src/utils/projectGraph.ts
+++ b/src/utils/projectGraph.ts
@@ -90,8 +90,8 @@ function dependsOnProjectWithError(project: Project, ignoreExtensionErrors: bool
  * Heuristically, returns a collection of projects that should be built (excluding, for example, downstream and base projects).
  * Note: Providing a list of monorepoPackages is a performance optimization - they'll be computed otherwise.
  */
-export async function getProjectsToBuild(repoDir: string, ignoreExtensionErrors: boolean = true, monorepoPackages?: readonly string[]): Promise<ProjectsToBuild> {
-    monorepoPackages = await utils.getMonorepoOrder(repoDir);
+export async function getProjectsToBuild(repoDir: string, monorepoPackages?: readonly string[], ignoreExtensionErrors: boolean = true): Promise<ProjectsToBuild> {
+    monorepoPackages = monorepoPackages ?? await utils.getMonorepoOrder(repoDir);
 
     const projectPaths = await getProjectPaths(repoDir, monorepoPackages);
 

--- a/src/utils/projectGraph.ts
+++ b/src/utils/projectGraph.ts
@@ -37,15 +37,15 @@ function getFileNameFromProjectName(projectName: string): string {
 }
 
 /**
- * Note that the returned projects are ordered in lerna scenarios -
+ * Note that the returned projects are ordered in monorepo scenarios -
  * they should be built in the order in which they are returned.
  */
-async function getProjectPaths(repoDir: string, lernaOrder: readonly string[]): Promise<readonly string[]> {
+async function getProjectPaths(repoDir: string, monorepoOrder: readonly string[]): Promise<readonly string[]> {
     const projectPaths = [];
     const seen = new Set<string>();
 
-    for (const lernaDir of lernaOrder) {
-        for (const path of (await utils.glob(lernaDir, "**/*tsconfig*.json"))) {
+    for (const monorepoDir of monorepoOrder) {
+        for (const path of (await utils.glob(monorepoDir, "**/*tsconfig*.json"))) {
             if (!seen.has(path)) {
                 seen.add(path);
                 projectPaths.push(path);
@@ -88,12 +88,12 @@ function dependsOnProjectWithError(project: Project, ignoreExtensionErrors: bool
 
 /**
  * Heuristically, returns a collection of projects that should be built (excluding, for example, downstream and base projects).
- * Note: Providing a list of lernaPackages is a performance optimization - they'll be computed otherwise.
+ * Note: Providing a list of monorepoPackages is a performance optimization - they'll be computed otherwise.
  */
-export async function getProjectsToBuild(repoDir: string, ignoreExtensionErrors: boolean = true, lernaPackages?: readonly string[]): Promise<ProjectsToBuild> {
-    lernaPackages = await utils.getLernaOrder(repoDir);
+export async function getProjectsToBuild(repoDir: string, ignoreExtensionErrors: boolean = true, monorepoPackages?: readonly string[]): Promise<ProjectsToBuild> {
+    monorepoPackages = await utils.getMonorepoOrder(repoDir);
 
-    const projectPaths = await getProjectPaths(repoDir, lernaPackages);
+    const projectPaths = await getProjectPaths(repoDir, monorepoPackages);
 
     const projectMap = new Map<string, Project>(); // path to data
     for (const projectPath of projectPaths) {

--- a/test/getTscErrors.test.ts
+++ b/test/getTscErrors.test.ts
@@ -17,6 +17,7 @@ describe("getErrors", () => {
     it("builds a simple project one time", async () => {
         const errors = await buildAndGetErrors(
             "./testResources/simpleProject",
+            /*monorepoPackages*/ [],
             /*isUserTestRepo*/ true,
             path.resolve("./testDownloads/getErrors/typescript-test-fake-error/built/local/tsc.js"),
             /*timeoutMs*/ 1e6,
@@ -35,6 +36,7 @@ describe("getErrors", () => {
     it("builds a script project one time", async () => {
         const errors = await buildAndGetErrors(
             "./testResources/scriptProject",
+            /*monorepoPackages*/ [],
             /*isUserTestRepo*/ true,
             path.resolve("./testDownloads/getErrors/typescript-test-fake-error/built/local/tsc.js"),
             /*timeoutMs*/ 1e6,
@@ -53,6 +55,7 @@ describe("getErrors", () => {
     xit("builds Real Live prettier, For Real", async () => {
         const errors = await buildAndGetErrors(
             "./testResources/scriptPrettier",
+            /*monorepoPackages*/ [],
             /*isUserTestRepo*/ false,
             path.resolve("./testDownloads/getErrors/typescript-test-fake-error/built/local/tsc.js"),
             /*timeoutMs*/ 1e6,


### PR DESCRIPTION
This reduces the number of package install steps in repros and saves time by avoiding duplicate installs.

Obviously, the pnpm change won't take effect until pnpm is re-enabled (though I've tested it locally).