### PR TITLE
Set disableLineTextInReferences=true in TS user preferences

### DIFF
--- a/src/utils/exerciseServer.ts
+++ b/src/utils/exerciseServer.ts
@@ -136,7 +136,7 @@ async function exerciseServerWorker(testDir: string, tsserverPath: string, repla
             "command": "configure",
             "arguments": {
                 "preferences": {
-                    "disableLineTextInReferences": false, // Match VS Code (and avoid uninteresting errors)
+                    "disableLineTextInReferences": true, // Match VS Code (and avoid uninteresting errors)
                     "includePackageJsonAutoImports": "off" // Handle per-request instead
                 },
                 "watchOptions": {


### PR DESCRIPTION
I sent https://github.com/microsoft/vscode/pull/171376 to enable this option in VS Code; we should match it here.

This should get rid of a lot of the annoying false positive error deltas on PRs.