### PR TITLE
Expand preferences for completions.

### DIFF
--- a/src/utils/exerciseServer.ts
+++ b/src/utils/exerciseServer.ts
@@ -137,7 +137,18 @@ async function exerciseServerWorker(testDir: string, tsserverPath: string, repla
             "arguments": {
                 "preferences": {
                     "disableLineTextInReferences": true, // Match VS Code (and avoid uninteresting errors)
-                    "includePackageJsonAutoImports": "off" // Handle per-request instead
+                    "includePackageJsonAutoImports": "off", // Handle per-request instead
+
+                    // Completions preferences
+                    "includeCompletionsForImportStatements": true,
+                    "includeCompletionsWithSnippetText": true,
+                    "includeAutomaticOptionalChainCompletions": true,
+                    "includeCompletionsWithInsertText": true,
+                    "includeCompletionsWithClassMemberSnippets": true,
+                    "allowIncompleteCompletions": true,
+
+                    // 'includeExternalModuleExports' configures this per request.
+                    "includeCompletionsForModuleExports": false,
                 },
                 "watchOptions": {
                     "excludeDirectories": ["**/node_modules"]
@@ -284,7 +295,6 @@ async function exerciseServerWorker(testDir: string, tsserverPath: string, repla
                             "line": line,
                             "offset": column,
                             "includeExternalModuleExports": prng.random() < 0.01, // auto-imports are too slow to test everywhere
-                            "includeInsertTextCompletions": true,
                             "triggerKind": 1,
                         }
                     }, isAt ? 0.5 : 0.001);
@@ -312,7 +322,6 @@ async function exerciseServerWorker(testDir: string, tsserverPath: string, repla
                                 "line": line,
                                 "offset": column,
                                 "includeExternalModuleExports": false,
-                                "includeInsertTextCompletions": true,
                                 "triggerKind": 2,
                                 "triggerCharacter": triggerChars[triggerCharIndex],
                             }

--- a/src/utils/exerciseServer.ts
+++ b/src/utils/exerciseServer.ts
@@ -137,7 +137,7 @@ async function exerciseServerWorker(testDir: string, tsserverPath: string, repla
             "arguments": {
                 "preferences": {
                     "disableLineTextInReferences": true, // Match VS Code (and avoid uninteresting errors)
-                    "includePackageJsonAutoImports": "off", // Handle per-request instead
+                    "includePackageJsonAutoImports": "auto",
 
                     // Completions preferences
                     "includeCompletionsForImportStatements": true,


### PR DESCRIPTION
Since we've stopped getting new reports, I'd like to start expanding the sorts of completion logic we end up requesting to be a little bit more typical of what VS Code is requesting from us. The old crawler was using all of these options with the exception of `includeCompletionsForModuleExports`. Apparently that's only done randomly in the interest of not spending too much time in completions.

I don't know how much slower the new-errors runs will become as a result of this - I haven't tried running it. But we can always dial this back if we want.