### PR TITLE
Ignore tsserver results when both results have identical request IDs and command names

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -285,6 +285,8 @@ async function getTsServerRepoResult(
                         ? prettyPrintServerHarnessOutput(oldSpawnResult.stdout, /*filter*/ false)
                         : `Timed out after ${executionTimeout} ms`));
 
+            // We don't want to drown PRs with comments.
+            // Override the results to say nothing interesting changed.
             if (isPr && newServerFailed && oldSpawnResult) {
                 const oldOut = parseServerHarnessOutput(oldSpawnResult.stdout);
                 const newOut = parseServerHarnessOutput(newSpawnResult.stdout);


### PR DESCRIPTION
While the tsc reporter will compare errors and hide when there's a diff, the tsserver reporter instead always reports if the current PR fails, including both traces.

It seems like all of our current spurious outputs (https://github.com/microsoft/TypeScript/pull/52809#issuecomment-1433779483) are cases where the errors have identical IDs and command names.

This PR makes it so that if they are identical, we ignore the problem.