### PR TITLE
Use placeholders for absolute paths in `completionEntryDetails`.

### DIFF
--- a/src/utils/exerciseServer.ts
+++ b/src/utils/exerciseServer.ts
@@ -320,7 +320,15 @@ async function exerciseServerWorker(testDir: string, tsserverPath: string, repla
                             const completionEntries = invokedResponse.body.entries;
                             for (let entry of completionEntries) {
                                 if (entry.hasAction && entry.source !== undefined && "data" in entry) {
-                                    const { name, source, data } = entry;
+                                    let { name, source, data } = entry;
+                                    // `source` may or may not be relative.
+                                    if (path.isAbsolute(source)) {
+                                        source = path.join(testDirPlaceholder, path.relative(testDir, source)).replace(/\\/g, "/");
+                                    }
+                                    // Technically data is supposed to be opaque... but what can you do?
+                                    if (typeof data.fileName === "string" && path.isAbsolute(data.fileName)) {
+                                       data.fileName = path.join(testDirPlaceholder, path.relative(testDir, data.fileName)).replace(/\\/g, "/");
+                                    }
                                     
                                     // 'completionEntryDetails' can take multiple entries; however, it's not useful for diagnostics
                                     // to report that "this command failed when asking for details on any of these 100 completions."


### PR DESCRIPTION
This fixes an issue that I know @andrewbranch, @MariaSolOs, and I have run into for replay logs using `completionEntryDetails`. `completionEntryDetails` often reuses data from the prior `completionInfo` request, which can contain absolute paths from the crawler session that are no longer valid for the replaying machine.