### PR TITLE
Add xterm.js to userTests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+!userTests/*.js/

--- a/userTests/xterm.js/test.json
+++ b/userTests/xterm.js/test.json
@@ -1,0 +1,5 @@
+{
+    "cloneUrl": "https://github.com/xtermjs/xterm.js.git",
+    "branch": "master",
+    "types": []
+}


### PR DESCRIPTION
This is the only test from TS proper that's missing here. I'm pretty sure this was missed as the gitignore thinks this is a JS file and excludes it.

Once this is in, we can feasibly remove all of the other tests from TS itself.