### PR TITLE
Revert "add `renovate` user test (#97)"

### DIFF
--- a/userTests/renovate/test.json
+++ b/userTests/renovate/test.json
@@ -1,5 +1,0 @@
-{
-  "cloneUrl": "https://github.com/renovatebot/renovate.git",
-  "branch": "main",
-  "types": []
-}


### PR DESCRIPTION
This reverts commit 409a2fd156f07accc310e8092172e4bebf781898.

This is currently broken and causing the error deltas repo to report unknown errors:

```
Starting #15 / 18: https://github.com/renovatebot/renovate.git
/home/vsts/work/1/s> sudo mount -t tmpfs -o size=4g tmpfs /mnt/ts_downloads
Cloning if absent
Cloning https://github.com/renovatebot/renovate.git into renovate
Installing packages if absent
Ignoring package install error from non-product folder test/e2e:
> Exited with code 1
> No stdout
> error "../../renovate-v0.0.0-semantic-release.tgz": Tarball is not in network and can not be located in cache (["/mnt/ts_downloads/renovate/renovate-v0.0.0-semantic-release.tgz","/home/vsts/.cache/yarn/v6/.tmp/c8dfa9055a0cda93989d5be6b4d41ff9/.yarn-tarball.tgz"])
/mnt/ts_downloads/renovate> yarn cache clean --all
yarn cache v1.22.19
success Cleared cache.
Done in 3.61s.

Testing with /home/vsts/work/1/s/typescript-53146/built/local/tsserver.js (new)
Killing process 3748 and its descendents: 3759
New server timed out after 600000 ms
Done https://github.com/renovatebot/renovate.git
Repo https://github.com/renovatebot/renovate.git had status "Unknown failure"
Cleaning up repo
/home/vsts/work/1/s> sudo umount /mnt/ts_downloads
```