### PR TITLE
Group concurrent errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -362,8 +362,8 @@ function groupErrors(summaries: Summary[]) {
             error = parseServerHarnessOutput(summary.tsServerResult.newSpawnResult!.stdout);
             group = groupedNewErrors;
         }
-        // Group old errors
         else if (summary.tsServerResult.oldServerFailed) {
+            // Group old errors
             const { oldSpawnResult } = summary.tsServerResult;
             error = oldSpawnResult?.stdout
                 ? parseServerHarnessOutput(oldSpawnResult.stdout)

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import fs = require("fs");
 import path = require("path");
 import mdEscape = require("markdown-escape");
 import randomSeed = require("random-seed");
+import { getErrorMessageFromStack, getHash, getHashForStack } from "./utils/hashStackTrace";
 
 interface Params {
     /**
@@ -84,9 +85,32 @@ export type RepoStatus =
     | "Detected no interesting changes"
     ;
 
+interface TSServerResult {
+    oldServerFailed: boolean;
+    oldSpawnResult?: SpawnResult;
+    newServerFailed: boolean;
+    newSpawnResult: SpawnResult;
+    replayScriptPath: string;
+    installCommands: ip.InstallCommand[];
+}
+
+interface Summary {
+    tsServerResult: TSServerResult;
+    repo: git.Repo;
+    oldTsEntrypointPath: string;
+    rawErrorArtifactPath: string;
+    replayScriptPath: string;
+    isUserTestRepo: boolean;
+    repoDir: string;
+    downloadDir: string;
+    replayScriptArtifactPath: string;
+    replayScriptName: string;
+    errorMessage: string | undefined;
+}
+
 interface RepoResult {
     readonly status: RepoStatus;
-    readonly summary?: string;
+    readonly tsServerResult?: TSServerResult;
     readonly replayScriptPath?: string;
     readonly rawErrorPath?: string;
 }
@@ -302,101 +326,23 @@ async function getTsServerRepoResult(
             }
         }
 
-        const owner = repo.owner ? `${mdEscape(repo.owner)}/` : "";
-        const url = repo.url ? `(${repo.url})` : "";
+        const tsServerResult = {
+            oldServerFailed,
+            oldSpawnResult,
+            newServerFailed,
+            newSpawnResult,
+            replayScriptPath,
+            installCommands,
+        };
 
-        let summary = `## [${owner}${mdEscape(repo.name)}]${url}\n`;
-
-        if (oldServerFailed) {
-            const oldServerError = oldSpawnResult?.stdout
-                ? prettyPrintServerHarnessOutput(oldSpawnResult.stdout, /*filter*/ true)
-                : `Timed out after ${executionTimeout} ms`;
-            summary += `
-<details>
-<summary>:warning: Note that ${path.basename(path.dirname(path.dirname(oldTsServerPath)))} had errors :warning:</summary>
-
-\`\`\`
-${oldServerError}
-\`\`\`
-
-</details>
-
-`;
-            if (!newServerFailed) {
-                summary += `
-:tada: New server no longer has errors :tada:
-`;
-                return { status: "Detected interesting changes", summary }
-            }
+        if (oldServerFailed && !newServerFailed) {
+            return { status: "Detected interesting changes", tsServerResult }
         }
-        
-        if (!newServerFailed) {
+        if (!newServerFailed) { 
             return { status: "Detected no interesting changes" };
         }
 
-        summary += `
-
-\`\`\`
-${prettyPrintServerHarnessOutput(newSpawnResult.stdout, /*filter*/ true)}
-\`\`\`
-That is a filtered view of the text. To see the raw error text, go to ${rawErrorArtifactPath}</code> in the <a href="${artifactFolderUrlPlaceholder}">artifact folder</a></li>\n
-`;
-
-        summary += `
-<details>
-<summary><h3>Last few requests</h3></summary>
-
-\`\`\`json
-${fs.readFileSync(replayScriptPath, { encoding: "utf-8" }).split(/\r?\n/).slice(-5).join("\n")}
-\`\`\`
-
-</details>
-
-`;
-
-        // Markdown doesn't seem to support a <details> list item, so this chunk is in HTML
-
-        summary += `<details>
-<summary><h3>Repro Steps</h3></summary>
-<ol>
-`;
-        if (isUserTestRepo) {
-            summary += `<li>Download user test <code>${repo.name}</code></li>\n`;
-        }
-        else {
-            summary += `<li><code>git clone ${repo.url!} --recurse-submodules</code></li>\n`;
-
-            try {
-                console.log("Extracting commit SHA for repro steps");
-                const commit = (await execAsync(repoDir, `git rev-parse @`)).trim();
-                summary += `<li>In dir <code>${repo.name}</code>, run <code>git reset --hard ${commit}</code></li>\n`;
-            }
-            catch {
-            }
-        }
-
-        if (installCommands.length > 1) {
-            summary += "<li><details><summary>Install packages (exact steps are below, but it might be easier to follow the repo readme)</summary><ol>\n";
-        }
-        for (const command of installCommands) {
-            summary += `  <li>In dir <code>${path.relative(downloadDir, command.directory)}</code>, run <code>${command.tool} ${command.arguments.join(" ")}</code></li>\n`;
-        }
-        if (installCommands.length > 1) {
-            summary += "</ol></details>\n";
-        }
-
-        // The URL of the artifact can be determined via AzDO REST APIs, but not until after the artifact is published
-        summary += `<li>Back in the initial folder, download <code>${replayScriptArtifactPath}</code> from the <a href="${artifactFolderUrlPlaceholder}">artifact folder</a></li>\n`;
-        summary += `<li><code>npm install --no-save @typescript/server-replay</code></li>\n`;
-        summary += `<li><code>npx tsreplay ./${repo.name} ./${replayScriptName} path/to/tsserver.js</code></li>\n`;
-        summary += `<li><code>npx tsreplay --help</code> to learn about helpful switches for debugging, logging, etc</li>\n`;
-
-        summary += `</ol>
-</details>
-
-`;
-
-        return { status: "Detected interesting changes", summary, replayScriptPath, rawErrorPath };
+        return { status: "Detected interesting changes", tsServerResult, replayScriptPath, rawErrorPath };
     }
     catch (err) {
         reportError(err, `Error running tsserver on ${repo.url ?? repo.name}`);
@@ -406,6 +352,123 @@ ${fs.readFileSync(replayScriptPath, { encoding: "utf-8" }).split(/\r?\n/).slice(
         console.log(`Done ${repo.url ?? repo.name}`);
         logStepTime(diagnosticOutput, repo, "language service", lsStart);
     }
+}
+
+function groupSummaries(summaries: Summary[]): Map<string, Summary[]> {
+    const group = new Map<string, Summary[]>();
+    for (const summary of summaries) {
+        const error = parseServerHarnessOutput(summary.tsServerResult.newSpawnResult!.stdout);
+
+        const key = typeof error === "string" ? getHash([error]) : getHashForStack(error.message);
+        const value = group.get(key) ?? [];
+        value.push(summary);
+        group.set(key, value);
+    }
+
+    return group;
+}
+
+function getErrorMessage(output: string): string {
+    const error = parseServerHarnessOutput(output);
+
+    return typeof error === "string" ? error : getErrorMessageFromStack(error.message);
+}
+
+async function createSummary(summaries: Summary[]): Promise<string | undefined> {
+    const { oldServerFailed, newServerFailed, newSpawnResult } = summaries[0].tsServerResult;
+
+    if (!oldServerFailed && !newServerFailed) {
+        return undefined;
+    }
+
+    let text = `<h2>${summaries[0].errorMessage}</h2>`;
+
+    // TODO: This prints if the old server also has the same error, or used to have an error.
+    //     if (oldServerFailed) {
+    //         const oldServerError = oldSpawnResult?.stdout
+    //             ? prettyPrintServerHarnessOutput(oldSpawnResult.stdout, /*filter*/ true)
+    //             : `Timed out after ${executionTimeout} ms`;
+    //         summary += `
+    // <details>
+    // <summary>:warning: Note that ${path.basename(path.dirname(path.dirname(oldTsServerPath)))} had errors :warning:</summary>
+
+    // \`\`\`
+    // ${oldServerError}
+    // \`\`\`
+
+    // </details>
+
+    // `;
+    //         if (!newServerFailed) {
+    //             summary += `
+    // :tada: New server no longer has errors :tada:
+    // `;
+    //             return summary;
+    //         }
+    //     }
+
+    text += `
+
+\`\`\`
+${prettyPrintServerHarnessOutput(newSpawnResult.stdout, /*filter*/ true)}
+\`\`\`
+
+<h4>Affected repos</h4>`;
+
+    for (const summary of summaries) {
+        const owner = summary.repo.owner ? `${mdEscape(summary.repo.owner)}/` : "";
+        const url = summary.repo.url ?? "";
+
+        text += `
+<details>
+<summary><a href="${url}">${owner + mdEscape(summary.repo.name)}</a></summary>
+Raw error text: <code>${summary.rawErrorArtifactPath}</code> in the <a href="${artifactFolderUrlPlaceholder}">artifact folder</a>
+<h4>Last few requests</h4>
+
+\`\`\`json
+${fs.readFileSync(summary.replayScriptPath, { encoding: "utf-8" }).split(/\r?\n/).slice(-5).join("\n")}
+\`\`\`
+
+<h4>Repro steps</h4>
+<ol>
+`;
+        if (summary.isUserTestRepo) {
+            text += `<li>Download user test <code>${summary.repo.name}</code></li>\n`;
+        }
+        else {
+            text += `<li><code>git clone ${summary.repo.url!} --recurse-submodules</code></li>\n`;
+
+            try {
+                console.log("Extracting commit SHA for repro steps");
+                const commit = (await execAsync(summary.repoDir, `git rev-parse @`)).trim();
+                text += `<li>In dir <code>${summary.repo.name}</code>, run <code>git reset --hard ${commit}</code></li>\n`;
+            }
+            catch {
+            }
+        }
+
+        if (summary.tsServerResult.installCommands.length > 1) {
+            text += "<li><details><summary>Install packages (exact steps are below, but it might be easier to follow the repo readme)</summary><ol>\n";
+        }
+        for (const command of summary.tsServerResult.installCommands) {
+            text += `  <li>In dir <code>${path.relative(summary.downloadDir, command.directory)}</code>, run <code>${command.tool} ${command.arguments.join(" ")}</code></li>\n`;
+        }
+        if (summary.tsServerResult.installCommands.length > 1) {
+            text += "</ol></details>\n";
+        }
+
+        // The URL of the artifact can be determined via AzDO REST APIs, but not until after the artifact is published
+        text += `<li>Back in the initial folder, download <code>${summary.replayScriptArtifactPath}</code> from the <a href="${artifactFolderUrlPlaceholder}">artifact folder</a></li>\n`;
+        text += `<li><code>npm install --no-save @typescript/server-replay</code></li>\n`;
+        text += `<li><code>npx tsreplay ./${summary.repo.name} ./${summary.replayScriptName} path/to/tsserver.js</code></li>\n`;
+        text += `<li><code>npx tsreplay --help</code> to learn about helpful switches for debugging, logging, etc</li>\n`;
+
+        text += `</ol>
+</details>
+`;
+    }
+
+    return text;
 }
 
 // Exported for testing
@@ -579,7 +642,9 @@ export async function getTscRepoResult(
         summary += "\n</details>\n\n";
 
         if (sawDifferentErrors) {
-            return { status: "Detected interesting changes", summary };
+            // TODO: Fix the summary
+            // return { status: "Detected interesting changes", summary };
+            return { status: "Detected interesting changes" };
         }
     }
     catch (err) {
@@ -658,6 +723,8 @@ export async function mainAsync(params: GitParams | UserParams): Promise<void> {
 
     const isPr = params.testType === "user" && !!params.prNumber
 
+    var summaries: Summary[] = [];
+
     let i = 1;
     for (const repo of repos) {
         console.log(`Starting #${i++} / ${repos.length}: ${repo.url ?? repo.name}`);
@@ -672,15 +739,30 @@ export async function mainAsync(params: GitParams | UserParams): Promise<void> {
                 : repo.name;
             const replayScriptFileName = `${repoPrefix}.${replayScriptFileNameSuffix}`;
             const rawErrorFileName = `${repoPrefix}.${rawErrorFileNameSuffix}`;
-            const { status, summary, replayScriptPath, rawErrorPath } = params.entrypoint === "tsc"
+
+            const rawErrorArtifactPath = path.join(params.resultDirName, rawErrorFileName);
+            const replayScriptArtifactPath = path.join(params.resultDirName, replayScriptFileName);
+
+            const { status, tsServerResult, replayScriptPath, rawErrorPath } = params.entrypoint === "tsc"
                 ? await getTscRepoResult(repo, userTestsDir, oldTsEntrypointPath, newTsEntrypointPath, params.buildWithNewWhenOldFails, downloadDir, diagnosticOutput)
-                : await getTsServerRepoResult(repo, userTestsDir, oldTsEntrypointPath, newTsEntrypointPath, downloadDir, path.join(params.resultDirName, replayScriptFileName), path.join(params.resultDirName, rawErrorFileName), diagnosticOutput, isPr);
+                : await getTsServerRepoResult(repo, userTestsDir, oldTsEntrypointPath, newTsEntrypointPath, downloadDir, replayScriptArtifactPath, rawErrorArtifactPath, diagnosticOutput, isPr);
             console.log(`Repo ${repo.url ?? repo.name} had status "${status}"`);
             statusCounts[status] = (statusCounts[status] ?? 0) + 1;
-            if (summary) {
 
-                const resultFileName = `${repoPrefix}.${resultFileNameSuffix}`;
-                await fs.promises.writeFile(path.join(resultDirPath, resultFileName), summary, { encoding: "utf-8" });
+            if (tsServerResult) {
+                summaries.push({
+                    tsServerResult,
+                    repo,
+                    oldTsEntrypointPath,
+                    rawErrorArtifactPath,
+                    replayScriptPath: path.join(downloadDir, path.basename(replayScriptArtifactPath)),
+                    isUserTestRepo: !repo.url,
+                    repoDir: path.join(downloadDir, repo.name),
+                    downloadDir,
+                    replayScriptArtifactPath,
+                    replayScriptName: path.basename(replayScriptArtifactPath),
+                    errorMessage: tsServerResult.newServerFailed ? getErrorMessage(tsServerResult.newSpawnResult.stdout) : undefined
+                });
 
                 // In practice, there will only be a replay script when the entrypoint is tsserver
                 // There can be replay steps without a summary, but then they're not interesting
@@ -690,9 +772,7 @@ export async function mainAsync(params: GitParams | UserParams): Promise<void> {
                 if (rawErrorPath) {
                     await fs.promises.copyFile(rawErrorPath, path.join(resultDirPath, rawErrorFileName));
                 }
-
             }
-
         }
         finally {
             // Throw away the repo so we don't run out of space
@@ -723,6 +803,19 @@ export async function mainAsync(params: GitParams | UserParams): Promise<void> {
                         throw e;
                     }
                 }
+            }
+        }
+    }
+
+    if (summaries.length > 0) {
+        // Group errors and create summary files.
+        const groupedSummary = groupSummaries(summaries);
+        for (let [key, value] of groupedSummary) {
+
+            const summary = await createSummary(value);
+            if (summary) {
+                const resultFileName = `${key}.${resultFileNameSuffix}`;
+                await fs.promises.writeFile(path.join(resultDirPath, resultFileName), summary, { encoding: "utf-8" });
             }
         }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -357,8 +357,8 @@ function groupErrors(summaries: Summary[]) {
     let group: Map<string, Summary[]>;
     let error: ServerHarnessOutput | string;
     for (const summary of summaries) {
-        // Group new errors
         if (summary.tsServerResult.newServerFailed) {
+            // Group new errors
             error = parseServerHarnessOutput(summary.tsServerResult.newSpawnResult!.stdout);
             group = groupedNewErrors;
         }

--- a/src/postGithubComments.ts
+++ b/src/postGithubComments.ts
@@ -55,7 +55,7 @@ else {
     summary = `Everything looks good!`;
 }
 
-// File starting with an exclamation point are old server errors.
+// Files starting with an exclamation point are old server errors.
 const hasOldErrors = pu.glob(resultDirPath, `**/!*.${resultFileNameSuffix}`).length !== 0;
 
 const resultPaths = pu.glob(resultDirPath, `**/*.${resultFileNameSuffix}`).sort((a, b) => path.basename(a).localeCompare(path.basename(b)));

--- a/src/postGithubComments.ts
+++ b/src/postGithubComments.ts
@@ -55,6 +55,9 @@ else {
     summary = `Everything looks good!`;
 }
 
+// File starting with an exclamation point are old server errors.
+const hasOldErrors = pu.glob(resultDirPath, `**/!*.${resultFileNameSuffix}`).length !== 0;
+
 const resultPaths = pu.glob(resultDirPath, `**/*.${resultFileNameSuffix}`).sort((a, b) => path.basename(a).localeCompare(path.basename(b)));
 const outputs = resultPaths.map(p => fs.readFileSync(p, { encoding: "utf-8" }).replace(new RegExp(artifactFolderUrlPlaceholder, "g"), artifactsUri));
 
@@ -67,9 +70,10 @@ if (!outputs.length) {
     git.createComment(+prNumber, +commentNumber, postResult, [header]);
 }
 else {
+    const oldErrorHeader = `<h2>:warning: Old server errors :warning:</h2>`;
     const openDetails = `\n\n<details>\n<summary>Details</summary>\n\n`;
     const closeDetails = `\n</details>`;
-    const initialHeader = header + openDetails;
+    const initialHeader = header + openDetails + (hasOldErrors ? oldErrorHeader : '');
     const continuationHeader = `@${userToTag} Here are some more interesting changes from running the ${suiteDescription} suite${openDetails}`;
     const trunctationSuffix = `\n:error: Truncated - see log for full output :error:`;
 

--- a/src/utils/hashStackTrace.ts
+++ b/src/utils/hashStackTrace.ts
@@ -1,7 +1,4 @@
-import { createHash } from "crypto";
-
-/** Matches any line containing 'tsserver.js' followed by line numbers. */
-const serverLinePattern = /tsserver\.js:(\d+)(?::(\d+))?/i;
+    import { createHash } from "crypto";
 
 export function getHash(methods: string[]): string {
     const lines = methods.join("\n");
@@ -9,16 +6,13 @@ export function getHash(methods: string[]): string {
 }
 
 export function getHashForStack(stack: string): string {
-    const stackLines = stack.split(/\r?\n|\r/);
+    const stackLines = stack.split(/\r?\n/);
 
-    const errorMessage = stackLines[1];
-
-    // We will only match methods that contains tsserver. Everything else is ignored.
-    return getHash([errorMessage, ...stackLines.filter(l => serverLinePattern.exec(l))]);
+    return getHash(stackLines);
 }
 
 export function getErrorMessageFromStack(stack: string): string {
-    const stackLines = stack.split(/\r?\n|\r/, 2);
+    const stackLines = stack.split(/\r?\n/, 2);
 
     return stackLines[1];
 }

--- a/src/utils/hashStackTrace.ts
+++ b/src/utils/hashStackTrace.ts
@@ -1,0 +1,32 @@
+import { createHash } from "crypto";
+
+/** Matches any line containing 'tsserver.js' followed by line numbers. */
+const serverLinePattern = /tsserver\.js:(\d+)(?::(\d+))?/i;
+
+export function getHash(methods: string[]): string {
+    const lines = methods.join("\n");
+    return createHash("md5").update(lines).digest("hex");
+}
+
+export function getHashForStack(stack: string): string {
+    const stackLines = stack.split(/\r?\n|\r/);
+    
+    const errorMessage = stackLines[1];
+    
+    const lines: string[] = [];
+    lines.push(errorMessage);
+    for (const stackLine of stackLines) {
+        // We will only match methods that contains tsserver. Everything else is ignored.
+        if (serverLinePattern.exec(stackLine)) {
+            lines.push(stackLine);
+        }
+    }
+
+    return getHash(lines);
+}
+
+export function getErrorMessageFromStack(stack: string): string {
+    const stackLines = stack.split(/\r?\n|\r/, 2);
+
+    return stackLines[1];
+}

--- a/src/utils/hashStackTrace.ts
+++ b/src/utils/hashStackTrace.ts
@@ -13,16 +13,8 @@ export function getHashForStack(stack: string): string {
     
     const errorMessage = stackLines[1];
     
-    const lines: string[] = [];
-    lines.push(errorMessage);
-    for (const stackLine of stackLines) {
-        // We will only match methods that contains tsserver. Everything else is ignored.
-        if (serverLinePattern.exec(stackLine)) {
-            lines.push(stackLine);
-        }
-    }
-
-    return getHash(lines);
+    // We will only match methods that contains tsserver. Everything else is ignored.
+    return getHash([errorMessage, ...stackLines.filter(l => serverLinePattern.exec(l));
 }
 
 export function getErrorMessageFromStack(stack: string): string {

--- a/src/utils/hashStackTrace.ts
+++ b/src/utils/hashStackTrace.ts
@@ -10,11 +10,11 @@ export function getHash(methods: string[]): string {
 
 export function getHashForStack(stack: string): string {
     const stackLines = stack.split(/\r?\n|\r/);
-    
+
     const errorMessage = stackLines[1];
-    
+
     // We will only match methods that contains tsserver. Everything else is ignored.
-    return getHash([errorMessage, ...stackLines.filter(l => serverLinePattern.exec(l));
+    return getHash([errorMessage, ...stackLines.filter(l => serverLinePattern.exec(l))]);
 }
 
 export function getErrorMessageFromStack(stack: string): string {


### PR DESCRIPTION
Fixes #100  

This changes how the error are displayed. Instead of showing an error per repository, it displays the "error message" as header and groups all of the repositories containing that error.

The group algorithm parses all of the stack lines containing "tsserver" and creates a hash based on that.

Important:
- The header is now an error message and not the last stack frame. This might generate some noise when grouping if the error message contains dynamic content as file paths or names. Nonetheless, I'm not sure if we have that scenario.
- Due to the app architecture is hard to sort the generated "summaries". That is because we generate files based on the hash instead of the error stack trace as it used.
- The way we put the "old errors" on top of the summary is hacky. We use a `!` character to make the sort to put it on top.