### PR TITLE
Ensure we detect userTests with build.sh

### DIFF
--- a/src/utils/userTestUtils.ts
+++ b/src/utils/userTestUtils.ts
@@ -11,8 +11,6 @@ interface UserConfig {
 }
 
 export function getUserTestsRepos(testDir: string): Repo[] {
-    // TODO: Figure out why chrome-devtools-frontend is failing.
-
     const repoDirectories = fs.readdirSync(`${testDir}`, { withFileTypes: true })
         .filter(value => value.isDirectory())
         .map(value => value.name);
@@ -29,7 +27,7 @@ export function getUserTestsRepos(testDir: string): Repo[] {
                 branch: config.branch,
             });
         }
-        else if (fs.existsSync(path.join(testDir, directory, "package.json"))) {
+        else if (fs.existsSync(path.join(testDir, directory, "package.json")) || fs.existsSync(path.join(testDir, directory, "build.sh"))) {
             repos.push({
                 name: directory,
             });


### PR DESCRIPTION
If you look at https://typescript.visualstudio.com/TypeScript/_build/results?buildId=153671&view=logs&j=98775127-73cc-5696-36a2-d2fef8930518&t=d9d396e3-92f1-565f-9165-fe54ddb28c95, it went from `sugar` straight to `ts-toolbelt`, skipping over `test262`.

It turns out that the function which reads out the `userTests` doesn't detect `build.sh` files.

As far as I can tell, this is just an oversight, and including them should "just work"?