### PR TITLE
add `renovate` user test

### DIFF
--- a/userTests/renovate/build.sh
+++ b/userTests/renovate/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+npm i -g yarn
+rm -rf renovate
+git clone --depth 1 https://github.com/renovatebot/renovate.git renovate
+START=$(pwd)
+cd $TS
+rm ~/.config/yarn/link/typescript
+yarn link
+cd $START/renovate
+yarn link typescript
+yarn type-check


### PR DESCRIPTION
[Renovate][1] is a large TypeScript project with over 12k GitHub stars. Not enough to make it into the top 100 TypeScript repositories on GitHub, although not far off! We frequently see issues with TypeScript updates. Most recently we hit microsoft/TypeScript#50479 with the upgrade to TypeScript 4.8. [Here's a search][2] for TypeScript upgrade PRs sorted by the number of comments.

Given the size and complexity of the Renovate codebase, as well as the frequency of issues we experience when upgrading TypeScript, I believe it is appropriate to include it in the test suite.

This PR is a 2nd attempt of #97. This time I managed to test locally and confirm that the test is working.

[1]: https://github.com/renovatebot/renovate
[2]: https://github.com/renovatebot/renovate/pulls?q=is%3Apr+sort%3Acomments-desc+author%3Aapp%2Frenovate+-is%3Aopen+in%3Atitle+%22update+dependency+typescript%22+