### PR TITLE
Switch default parallelism to 8 machines

### DIFF
--- a/azure-pipelines-gitTests-template.yml
+++ b/azure-pipelines-gitTests-template.yml
@@ -26,7 +26,7 @@ parameters:
   - name: MACHINE_COUNT
     displayName: Machine Count
     type: number
-    default: 4
+    default: 8
   - name: ENTRYPOINT
     displayName: TypeScript entrypoint
     type: string

--- a/azure-pipelines-gitTests.yml
+++ b/azure-pipelines-gitTests.yml
@@ -26,7 +26,7 @@ parameters:
   - name: MACHINE_COUNT
     displayName: Machine Count
     type: number
-    default: 4
+    default: 8
     values:
     - 1
     - 2

--- a/azure-pipelines-userTests.yml
+++ b/azure-pipelines-userTests.yml
@@ -35,7 +35,7 @@ parameters:
   - name: MACHINE_COUNT
     displayName: Machine Count
     type: number
-    default: 4
+    default: 8
     values:
     - 1
     - 2


### PR DESCRIPTION
The top100 run can easily take an hour and a half, even with 4 machines. I think we should be fine to just double this to 8 for all pipelines (so also user tests and such) and go faster.