### PR TITLE
add `type-fest` user test

### DIFF
--- a/userTests/type-fest/test.json
+++ b/userTests/type-fest/test.json
@@ -1,0 +1,5 @@
+{
+  "cloneUrl": "https://github.com/sindresorhus/type-fest.git",
+  "branch": "main",
+  "types": []
+}


### PR DESCRIPTION
In the `type-fest` type library there are a lot of complex usages of types and as such it often finds edge cases not seen elsewhere.

I have tried to have a canary test there and will have again when this gets merged: https://github.com/sindresorhus/type-fest/pull/785

But even when running that frequently against nightlies it can be hard to pinpoint what it was that caused something to break, as seen here: https://github.com/sindresorhus/type-fest/issues/784

I personally would find it great if `type-fest` could be tested here, especially so as its relied upon by many well-used module, resulting in +151 million weekly downloads from npm.

That way we can more early discover if there's an incompatibility and aid in helping out on solving it.

/ Pelle, co-maintainer of `type-fest`