### PR TITLE
Restore test repos to post-install state before starting second compile

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -677,6 +677,7 @@ export async function getTscRepoResult(
     finally {
         console.log("Unstaging installed files");
         await execAsync(repoDir, "git restore .");
+        await execAsync(repoDir, "git clean -xdff");
         await execAsync(repoDir, "git restore --staged .");
 
         logStepTime(diagnosticOutput, repo, "build", buildStart);

--- a/src/main.ts
+++ b/src/main.ts
@@ -676,6 +676,7 @@ export async function getTscRepoResult(
     }
     finally {
         console.log("Unstaging installed files");
+        await execAsync(repoDir, "git restore .");
         await execAsync(repoDir, "git restore --staged .");
 
         logStepTime(diagnosticOutput, repo, "build", buildStart);


### PR DESCRIPTION
I believe that this should fix most of the weirdness seen in PR runs; we were running tsc twice, but the second run was different because it had the results of the first tsc run. Some repos have tsconfigs we heuristically choose to run which place files in weird places that affect other runs, so it's more desirable to go back to the same state when running a second time.