### PR TITLE
Disable tmpfs to try and work around memory limit

### DIFF
--- a/src/checkGithubRepos.ts
+++ b/src/checkGithubRepos.ts
@@ -12,7 +12,7 @@ const [,, entrypoint, oldTsNpmVersion, newTsNpmVersion, repoListPath, workerCoun
 
 mainAsync({
     testType: "github",
-    tmpfs: true,
+    tmpfs: false,
     entrypoint: entrypoint as TsEntrypoint,
     diagnosticOutput: diagnosticOutput.toLowerCase() === "true",
     buildWithNewWhenOldFails: false,

--- a/src/checkUserTestRepos.ts
+++ b/src/checkUserTestRepos.ts
@@ -12,7 +12,7 @@ const [,, entrypoint, oldTsRepoUrl, oldHeadRef, prNumber, buildWithNewWhenOldFai
 
 mainAsync({
     testType: "user",
-    tmpfs: true,
+    tmpfs: false,
     entrypoint: entrypoint as TsEntrypoint,
     oldTsRepoUrl,
     oldHeadRef,


### PR DESCRIPTION
Disabling tmpfs for now to see if it's fast enough; tmpfs limited to memory, and after my previous `git add --force .` change for snapshotting, some repos fail for being too large.

If this doesn't work, I'll revert this and instead switch to a custom pool with more memory.