### PR TITLE
Revert recent changes

### DIFF
--- a/src/checkGithubRepos.ts
+++ b/src/checkGithubRepos.ts
@@ -12,7 +12,7 @@ const [,, entrypoint, oldTsNpmVersion, newTsNpmVersion, repoListPath, workerCoun
 
 mainAsync({
     testType: "github",
-    tmpfs: false,
+    tmpfs: true,
     entrypoint: entrypoint as TsEntrypoint,
     diagnosticOutput: diagnosticOutput.toLowerCase() === "true",
     buildWithNewWhenOldFails: false,

--- a/src/checkUserTestRepos.ts
+++ b/src/checkUserTestRepos.ts
@@ -12,7 +12,7 @@ const [,, entrypoint, oldTsRepoUrl, oldHeadRef, prNumber, buildWithNewWhenOldFai
 
 mainAsync({
     testType: "user",
-    tmpfs: false,
+    tmpfs: true,
     entrypoint: entrypoint as TsEntrypoint,
     oldTsRepoUrl,
     oldHeadRef,

--- a/src/main.ts
+++ b/src/main.ts
@@ -518,10 +518,6 @@ export async function getTscRepoResult(
 
     const buildStart = performance.now();
     try {
-        // Force add all of the ignored files we just installed so we can git clean to go back to this state later.
-        console.log("Staging installed files");
-        await execAsync(repoDir, "git add --force .");
-            
         console.log(`Building with ${oldTscPath} (old)`);
         const oldErrors = await ge.buildAndGetErrors(repoDir, monorepoPackages, isUserTestRepo, oldTscPath, executionTimeout, /*skipLibCheck*/ true);
 
@@ -561,10 +557,6 @@ export async function getTscRepoResult(
             console.log(oldFailuresMessage);
             summary += `**${oldFailuresMessage}**\n`;
         }
-
-        console.log("Restoring repo to post-install state");
-        await execAsync(repoDir, "git restore .");
-        await execAsync(repoDir, "git clean -xdff");
 
         console.log(`Building with ${newTscPath} (new)`);
         const newErrors = await ge.buildAndGetErrors(repoDir, monorepoPackages, isUserTestRepo, newTscPath, executionTimeout, /*skipLibCheck*/ true);
@@ -675,11 +667,6 @@ export async function getTscRepoResult(
         return { status: "Unknown failure" };
     }
     finally {
-        console.log("Unstaging installed files");
-        await execAsync(repoDir, "git restore .");
-        await execAsync(repoDir, "git clean -xdff");
-        await execAsync(repoDir, "git restore --staged .");
-
         logStepTime(diagnosticOutput, repo, "build", buildStart);
     }
 


### PR DESCRIPTION
These changes caused more failures than they fixed. The install restoration system used too much disk space, and since it was on tmpfs, ran out of memory. Will retry another time, but I want to unblock these.