### PR TITLE
Disable compliance jobs in workers

### DIFF
--- a/azure-pipelines-gitTests.yml
+++ b/azure-pipelines-gitTests.yml
@@ -66,6 +66,10 @@ trigger: none
 pool:
   vmImage: 'ubuntu-latest'
 
+variables:
+  Codeql.Enabled: false
+  skipComponentGovernanceDetection: true
+
 extends:
   template: azure-pipelines-gitTests-template.yml
   parameters:

--- a/azure-pipelines-userTests.yml
+++ b/azure-pipelines-userTests.yml
@@ -60,6 +60,10 @@ trigger: none
 pool:
   vmImage: 'ubuntu-latest'
 
+variables:
+  Codeql.Enabled: false
+  skipComponentGovernanceDetection: true
+
 jobs:
 - job: ListRepos
   steps:


### PR DESCRIPTION
If something goes wrong during testing, the checks can leave files behind, which then get code scanned. That's definitely not intentional. Disable these (like I do in the benchmarker).