### PR TITLE
Fix bot reply emoji when nothing changed

### DIFF
--- a/src/postGithubComments.ts
+++ b/src/postGithubComments.ts
@@ -78,7 +78,7 @@ let header = `@${userToTag} Here are the results of running the ${suiteDescripti
 ${summary.join("\n")}`;
 
 if (!outputs.length) {
-    git.createComment(+prNumber, +commentNumber, distinctId, postResult, [header], true);
+    git.createComment(+prNumber, +commentNumber, distinctId, postResult, [header], somethingChanged);
 }
 else {
     const oldErrorHeader = `<h2>:warning: Old server errors :warning:</h2>`;


### PR DESCRIPTION
I think I thought this path would never run, but clearly when outputs is empty that doesn't mean something changed. Just use the variable.