### PR TITLE
Fix typescript-eslint

### DIFF
--- a/userTests/typescript-eslint/build.sh
+++ b/userTests/typescript-eslint/build.sh
@@ -7,10 +7,13 @@ cd typescript-eslint
 
 export NX_NO_CLOUD=true
 
-npx json -I -f package.json -e "this.resolutions.typescript = 'file:$TS'"
-git diff
+time yarn
 
-yarn
+export SKIP_POSTINSTALL=true
+npx json -I -f package.json -e "this.resolutions.typescript = 'file:$TS'"
+
+time yarn
+
 yarn tsc --version
 
-yarn build
+yarn typecheck

--- a/userTests/typescript-eslint/build.sh
+++ b/userTests/typescript-eslint/build.sh
@@ -1,0 +1,16 @@
+set -x
+
+command -v yarn &> /dev/null || npm i -g yarn
+rm -rf typescript-eslint
+git clone --depth 1 https://github.com/typescript-eslint/typescript-eslint.git typescript-eslint
+cd typescript-eslint
+
+export NX_NO_CLOUD=true
+
+npx json -I -f package.json -e "this.resolutions.typescript = 'file:$TS'"
+git diff
+
+yarn
+yarn tsc --version
+
+yarn typecheck

--- a/userTests/typescript-eslint/build.sh
+++ b/userTests/typescript-eslint/build.sh
@@ -13,4 +13,4 @@ git diff
 yarn
 yarn tsc --version
 
-yarn typecheck
+yarn build

--- a/userTests/typescript-eslint/test.json
+++ b/userTests/typescript-eslint/test.json
@@ -1,4 +1,0 @@
-{
-  "cloneUrl": "https://github.com/typescript-eslint/typescript-eslint.git",
-  "types": []
-}


### PR DESCRIPTION
This has been failing since the start; our auto-install system gets confused by the dummypkg and tries to install it, even though it's not a part of ts-eslint's monorepo and that makes yarn sad.

```
Starting #2 / 6: https://github.com/typescript-eslint/typescript-eslint.git
/mnt/vss/_work/1/s> sudo mount -t tmpfs -o size=4g tmpfs /mnt/ts_downloads
Cloning if absent
Cloning https://github.com/typescript-eslint/typescript-eslint.git into typescript-eslint
Installing packages if absent
/mnt/ts_downloads/typescript-eslint> yarn cache clean --all
➤ YN0000: Done in 0s 109ms

Error installing packages for typescript-eslint:
> Error: Failed to install packages for tools/dummypkg:
> Exited with code 1
> Usage Error: The nearest package directory (/mnt/ts_downloads/typescript-eslint/tools/dummypkg) doesn't seem to be part of the project declared in /mnt/ts_downloads/typescript-eslint.
> 
> - If /mnt/ts_downloads/typescript-eslint isn't intended to be a project, remove any yarn.lock and/or package.json file there.
> - If /mnt/ts_downloads/typescript-eslint is intended to be a project, it might be that you forgot to list tools/dummypkg in its workspace configuration.
> - Finally, if /mnt/ts_downloads/typescript-eslint is fine and you intend tools/dummypkg to be treated as a completely separate project (not even a workspace), create an empty yarn.lock file in it.
> 
> $ yarn install [--json] [--immutable] [--immutable-cache] [--check-cache] [--inline-builds] [--mode #0]
> No stderr
>     at installPackages (/mnt/vss/_work/1/s/dist/main.js:666:27)
>     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
>     at async installPackagesAndGetCommands (/mnt/vss/_work/1/s/dist/main.js:69:9)
>     at async getTscRepoResult (/mnt/vss/_work/1/s/dist/main.js:338:31)
>     at async mainAsync (/mnt/vss/_work/1/s/dist/main.js:523:19)
Repo https://github.com/typescript-eslint/typescript-eslint.git had status "Package install failed"
Cleaning up repo
```

Instead, move it over to a script, like we do vscode, prettier, pyright.

This fails but for a better reason:

```
+ yarn build

 NX   Nx Cloud Manually Disabled

Nx will continue running, but nothing will be written or read from the remote cache.
Run details will also not be available in the Nx Cloud UI.

If this wasn't intentional, check for the NX_NO_CLOUD environment variable, the --no-cloud flag


 NX   Running target build for 13 projects and 1 task they depend on:

- rule-schema-to-typescript-types
- eslint-plugin-internal
- typescript-eslint
- typescript-estree
- eslint-plugin
- scope-manager
- visitor-keys
- rule-tester
- type-utils
- ast-spec
- parser
- types
- utils



> nx run ast-spec:build  [existing outputs match the cache, left as is]


api-extractor 7.38.0  - https://api-extractor.com/

Using configuration from ./api-extractor.json
Analysis will use the bundled TypeScript version 5.5.0-dev

API Extractor completed successfully

> nx run types:copy-ast-spec  [existing outputs match the cache, left as is]

src/generated/ast-spec.ts 286ms
Copied ast-spec.ts

> nx run types:build  [existing outputs match the cache, left as is]


> nx run visitor-keys:build  [existing outputs match the cache, left as is]


> nx run typescript-estree:build

src/ts-estree/ts-nodes.ts(189,8): error TS2694: Namespace 'ts' has no exported member 'InputFiles'.
src/ts-estree/ts-nodes.ts(191,8): error TS2694: Namespace 'ts' has no exported member 'UnparsedSource'.
src/convert.ts(264,31): error TS2345: Argument of type 'Omit<TSESTreeToTSNode<T>, "parent">' is not assignable to parameter of type 'Pick<Node, "getEnd" | "getStart">'.
  Type 'Omit<TSESTreeToTSNode<T>, "parent">' is missing the following properties from type 'Pick<Node, "getEnd" | "getStart">': getEnd, getStart
src/convert.ts(845,45): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(857,43): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(997,63): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(1011,54): error TS7006: Parameter 'declaration' implicitly has an 'any' type.
src/convert.ts(1011,67): error TS7006: Parameter 'i' implicitly has an 'any' type.
src/convert.ts(1041,47): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(1047,38): error TS7006: Parameter 'declaration' implicitly has an 'any' type.
src/convert.ts(1047,51): error TS7006: Parameter 'i' implicitly has an 'any' type.
src/convert.ts(1085,41): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(1092,39): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(1103,45): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(1317,47): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(1469,39): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(1483,41): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(1611,36): error TS7006: Parameter 'templateSpan' implicitly has an 'any' type.
src/convert.ts(1827,24): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(1913,64): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(1956,60): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(2182,41): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(2223,38): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(2368,39): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(2376,39): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(2399,60): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(2427,58): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(2575,37): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(2697,43): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(2815,36): error TS7006: Parameter 'member' implicitly has an 'any' type.
src/convert.ts(2893,37): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(3041,33): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(3047,33): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(3118,48): error TS7006: Parameter 'el' implicitly has an 'any' type.
src/convert.ts(3166,36): error TS7006: Parameter 'templateSpan' implicitly has an 'any' type.
src/convert.ts(604,7): error TS2578: Unused '@ts-expect-error' directive.



 NX   Running target build for 13 projects and 1 task they depend on failed

Tasks not run because their dependencies failed or --nx-bail=true:

- rule-schema-to-typescript-types:build
- eslint-plugin-internal:build
- typescript-eslint:build
- eslint-plugin:build
- scope-manager:build
- rule-tester:build
- type-utils:build
- parser:build
- utils:build

Failed tasks:

- typescript-estree:build
```

i.e. that we removed a bunch of deprecated junk.