### PR TITLE
Use overlay FS when building projects

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,12 +23,22 @@
             "type": "npm",
             "script": "build",
             "group": {
-                "kind": "build",
-                "isDefault": true
+                "kind": "build"
             },
             "problemMatcher": [],
             "label": "npm: build",
             "detail": "tsc -b ."
+        },
+        {
+            "label": "tsc: watch ./src",
+            "type": "shell",
+            "command": "node",
+            "args": ["${workspaceFolder}/node_modules/typescript/lib/tsc.js", "--build", ".", "--watch"],
+            "group": "build",
+            "isBackground": true,
+            "problemMatcher": [
+                "$tsc-watch"
+            ]
         },
         {
             "label": "Clean all",

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import path = require("path");
 import mdEscape = require("markdown-escape");
 import randomSeed = require("random-seed");
 import { getErrorMessageFromStack, getHash, getHashForStack } from "./utils/hashStackTrace";
+import { createCopyingOverlayFS, createTempOverlayFS, OverlayBaseFS } from "./utils/overlayFS";
 
 interface Params {
     /**
@@ -100,7 +101,6 @@ interface Summary {
     oldTsEntrypointPath: string;
     rawErrorArtifactPath: string;
     replayScript: string;
-    downloadDir: string;
     replayScriptArtifactPath: string;
     replayScriptName: string;
     commit?: string;
@@ -207,35 +207,41 @@ async function getTsServerRepoResult(
     userTestsDir: string,
     oldTsServerPath: string,
     newTsServerPath: string,
-    downloadDir: string,
+    downloadDir: OverlayBaseFS,
     replayScriptArtifactPath: string,
     rawErrorArtifactPath: string,
     diagnosticOutput: boolean,
     isPr: boolean,
 ): Promise<RepoResult> {
 
-    if (!await cloneRepo(repo, userTestsDir, downloadDir, diagnosticOutput)) {
+    if (!await cloneRepo(repo, userTestsDir, downloadDir.path, diagnosticOutput)) {
         return { status: "Git clone failed" };
     }
 
-    const repoDir = path.join(downloadDir, repo.name);
-    const monorepoPackages = await getMonorepoPackages(repoDir);
+    const baseRepoDir = path.join(downloadDir.path, repo.name);
+    const monorepoPackages = await getMonorepoPackages(baseRepoDir);
 
     // Presumably, people occasionally browse repos without installing the packages first
     const installCommands = (prng.random() > 0.2) && monorepoPackages
-        ? (await installPackagesAndGetCommands(repo, downloadDir, repoDir, monorepoPackages, /*cleanOnFailure*/ true, diagnosticOutput))!
+        ? (await installPackagesAndGetCommands(repo, downloadDir.path, baseRepoDir, monorepoPackages, /*cleanOnFailure*/ true, diagnosticOutput))!
         : [];
 
     const replayScriptName = path.basename(replayScriptArtifactPath);
-    const replayScriptPath = path.join(downloadDir, replayScriptName);
+    const replayScriptPath = path.join(downloadDir.path, replayScriptName);
 
     const rawErrorName = path.basename(rawErrorArtifactPath);
-    const rawErrorPath = path.join(downloadDir, rawErrorName);
+    const rawErrorPath = path.join(downloadDir.path, rawErrorName);
 
     const lsStart = performance.now();
     try {
         console.log(`Testing with ${newTsServerPath} (new)`);
-        const newSpawnResult = await spawnWithTimeoutAsync(repoDir, process.argv[0], [path.join(__dirname, "utils", "exerciseServer.js"), repoDir, replayScriptPath, newTsServerPath, diagnosticOutput.toString(), prng.string(10)], executionTimeout);
+        let newSpawnResult;
+        {
+            await using overlay = await downloadDir.createOverlay();
+            const repoDir = path.join(overlay.path, repo.name);
+            newSpawnResult = await spawnWithTimeoutAsync(repoDir, process.argv[0], [path.join(__dirname, "utils", "exerciseServer.js"), repoDir, replayScriptPath, newTsServerPath, diagnosticOutput.toString(), prng.string(10)], executionTimeout);
+        }
+
         if (!newSpawnResult) {
             // CONSIDER: It might be interesting to treat timeouts as failures, but they'd be harder to baseline and more likely to have flaky repros
             console.log(`New server timed out after ${executionTimeout} ms`);
@@ -285,7 +291,12 @@ async function getTsServerRepoResult(
         }
 
         console.log(`Testing with ${oldTsServerPath} (old)`);
-        const oldSpawnResult = await spawnWithTimeoutAsync(repoDir, process.argv[0], [path.join(__dirname, "..", "node_modules", "@typescript", "server-replay", "replay.js"), repoDir, replayScriptPath, oldTsServerPath, "-u"], executionTimeout);
+        let oldSpawnResult;
+        {
+            await using overlay = await downloadDir.createOverlay();
+            const repoDir = path.join(overlay.path, repo.name);
+            oldSpawnResult = await spawnWithTimeoutAsync(repoDir, process.argv[0], [path.join(__dirname, "..", "node_modules", "@typescript", "server-replay", "replay.js"), repoDir, replayScriptPath, oldTsServerPath, "-u"], executionTimeout);
+        }
 
         if (diagnosticOutput && oldSpawnResult) {
             console.log("Raw spawn results (old):");
@@ -468,7 +479,7 @@ ${summary.replayScript}
             text += "<li><details><summary>Install packages (exact steps are below, but it might be easier to follow the repo readme)</summary><ol>\n";
         }
         for (const command of summary.tsServerResult.installCommands) {
-            text += `  <li>In dir <code>${path.relative(summary.downloadDir, command.directory)}</code>, run <code>${command.tool} ${command.arguments.join(" ")}</code></li>\n`;
+            text += `  <li>In dir <code>${command.prettyDirectory}</code>, run <code>${command.tool} ${command.arguments.join(" ")}</code></li>\n`;
         }
         if (summary.tsServerResult.installCommands.length > 1) {
             text += "</ol></details>\n";
@@ -500,17 +511,18 @@ export async function getTscRepoResult(
      *   2) Errors are expected when building with the old tsc and we're specifically interested in changes (user tests)
      */
     buildWithNewWhenOldFails: boolean,
-    downloadDir: string,
-    diagnosticOutput: boolean): Promise<RepoResult> {
+    downloadDir: OverlayBaseFS,
+    diagnosticOutput: boolean,
+): Promise<RepoResult> {
 
-    if (!await cloneRepo(repo, userTestsDir, downloadDir, diagnosticOutput)) {
+    if (!await cloneRepo(repo, userTestsDir, downloadDir.path, diagnosticOutput)) {
         return { status: "Git clone failed" };
     }
 
-    const repoDir = path.join(downloadDir, repo.name);
-    const monorepoPackages = await getMonorepoPackages(repoDir);
+    const baseRepoDir = path.join(downloadDir.path, repo.name);
+    const monorepoPackages = await getMonorepoPackages(baseRepoDir);
 
-    if (!monorepoPackages || !await installPackagesAndGetCommands(repo, downloadDir, repoDir, monorepoPackages, /*cleanOnFailure*/ false, diagnosticOutput)) {
+    if (!monorepoPackages || !await installPackagesAndGetCommands(repo, downloadDir.path, baseRepoDir, monorepoPackages, /*cleanOnFailure*/ false, diagnosticOutput)) {
         return { status: "Package install failed" };
     }
 
@@ -519,7 +531,12 @@ export async function getTscRepoResult(
     const buildStart = performance.now();
     try {
         console.log(`Building with ${oldTscPath} (old)`);
-        const oldErrors = await ge.buildAndGetErrors(repoDir, monorepoPackages, isUserTestRepo, oldTscPath, executionTimeout, /*skipLibCheck*/ true);
+        let oldErrors;
+        {
+            await using overlay = await downloadDir.createOverlay();
+            const repoDir = path.join(overlay.path, repo.name);
+            oldErrors = await ge.buildAndGetErrors(repoDir, monorepoPackages, isUserTestRepo, oldTscPath, executionTimeout, /*skipLibCheck*/ true);
+        }
 
         if (oldErrors.hasConfigFailure) {
             console.log("Unable to build project graph");
@@ -559,7 +576,12 @@ export async function getTscRepoResult(
         }
 
         console.log(`Building with ${newTscPath} (new)`);
-        const newErrors = await ge.buildAndGetErrors(repoDir, monorepoPackages, isUserTestRepo, newTscPath, executionTimeout, /*skipLibCheck*/ true);
+        let newErrors;
+        {
+            await using overlay = await downloadDir.createOverlay();
+            const repoDir = path.join(overlay.path, repo.name);
+            newErrors = await ge.buildAndGetErrors(repoDir, monorepoPackages, isUserTestRepo, newTscPath, executionTimeout, /*skipLibCheck*/ true);
+        }
 
         if (newErrors.hasConfigFailure) {
             console.log("Unable to build project graph");
@@ -704,13 +726,8 @@ export async function mainAsync(params: GitParams | UserParams): Promise<void> {
         prng.seed(params.prngSeed);
     }
 
-    const downloadDir = params.tmpfs ? "/mnt/ts_downloads" : path.join(processCwd, "ts_downloads");
-    // TODO: check first whether the directory exists and skip downloading if possible
-    // TODO: Seems like this should come after the typescript download
-    if (params.tmpfs)
-        await execAsync(processCwd, "sudo mkdir " + downloadDir);
-    else
-        await execAsync(processCwd, "mkdir " + downloadDir);
+    const downloadDirPath = params.tmpfs ? "/mnt/ts_downloads" : path.join(processCwd, "ts_downloads");
+    const createFs = params.tmpfs ? createTempOverlayFS : createCopyingOverlayFS;
 
     const resultDirPath = path.join(processCwd, params.resultDirName);
 
@@ -743,98 +760,63 @@ export async function mainAsync(params: GitParams | UserParams): Promise<void> {
     let i = 1;
     for (const repo of repos) {
         console.log(`Starting #${i++} / ${repos.length}: ${repo.url ?? repo.name}`);
-        if (params.tmpfs) {
-            await execAsync(processCwd, "sudo mount -t tmpfs -o size=4g tmpfs " + downloadDir);
-        }
+
+        await using downloadDir = await createFs(downloadDirPath);
 
         const diagnosticOutput = !!params.diagnosticOutput;
-        try {
-            const repoPrefix = repo.owner
-                ? `${repo.owner}.${repo.name}`
-                : repo.name;
-            const replayScriptFileName = `${repoPrefix}.${replayScriptFileNameSuffix}`;
-            const rawErrorFileName = `${repoPrefix}.${rawErrorFileNameSuffix}`;
+        const repoPrefix = repo.owner
+            ? `${repo.owner}.${repo.name}`
+            : repo.name;
+        const replayScriptFileName = `${repoPrefix}.${replayScriptFileNameSuffix}`;
+        const rawErrorFileName = `${repoPrefix}.${rawErrorFileNameSuffix}`;
 
-            const rawErrorArtifactPath = path.join(params.resultDirName, rawErrorFileName);
-            const replayScriptArtifactPath = path.join(params.resultDirName, replayScriptFileName);
+        const rawErrorArtifactPath = path.join(params.resultDirName, rawErrorFileName);
+        const replayScriptArtifactPath = path.join(params.resultDirName, replayScriptFileName);
 
-            const { status, summary, tsServerResult, replayScriptPath, rawErrorPath } = params.entrypoint === "tsc"
-                ? await getTscRepoResult(repo, userTestsDir, oldTsEntrypointPath, newTsEntrypointPath, params.buildWithNewWhenOldFails, downloadDir, diagnosticOutput)
-                : await getTsServerRepoResult(repo, userTestsDir, oldTsEntrypointPath, newTsEntrypointPath, downloadDir, replayScriptArtifactPath, rawErrorArtifactPath, diagnosticOutput, isPr);
-            console.log(`Repo ${repo.url ?? repo.name} had status "${status}"`);
-            statusCounts[status] = (statusCounts[status] ?? 0) + 1;
+        const { status, summary, tsServerResult, replayScriptPath, rawErrorPath } = params.entrypoint === "tsc"
+            ? await getTscRepoResult(repo, userTestsDir, oldTsEntrypointPath, newTsEntrypointPath, params.buildWithNewWhenOldFails, downloadDir, diagnosticOutput)
+            : await getTsServerRepoResult(repo, userTestsDir, oldTsEntrypointPath, newTsEntrypointPath, downloadDir, replayScriptArtifactPath, rawErrorArtifactPath, diagnosticOutput, isPr);
+        console.log(`Repo ${repo.url ?? repo.name} had status "${status}"`);
+        statusCounts[status] = (statusCounts[status] ?? 0) + 1;
 
-            if (summary) {
-                const resultFileName = `${repoPrefix}.${resultFileNameSuffix}`;
-                await fs.promises.writeFile(path.join(resultDirPath, resultFileName), summary, { encoding: "utf-8" });
-            }
-
-            if (tsServerResult) {
-                const replayScriptPath = path.join(downloadDir, path.basename(replayScriptArtifactPath));
-                const repoDir = path.join(downloadDir, repo.name);
-
-                let commit: string | undefined;
-                try {
-                    console.log("Extracting commit SHA for repro steps");
-                    commit = (await execAsync(repoDir, `git rev-parse @`)).trim()
-                }
-                catch {
-                    //noop
-                }
-
-                summaries.push({
-                    tsServerResult,
-                    repo,
-                    oldTsEntrypointPath,
-                    rawErrorArtifactPath,
-                    replayScript: fs.readFileSync(replayScriptPath, { encoding: "utf-8" }).split(/\r?\n/).slice(-5).join("\n"),
-                    downloadDir,
-                    replayScriptArtifactPath,
-                    replayScriptName: path.basename(replayScriptArtifactPath),
-                    commit
-                });
-            }
-
-            if (summary || tsServerResult) {
-                // In practice, there will only be a replay script when the entrypoint is tsserver
-                // There can be replay steps without a summary, but then they're not interesting
-                if (replayScriptPath) {
-                    await fs.promises.copyFile(replayScriptPath, path.join(resultDirPath, replayScriptFileName));
-                }
-                if (rawErrorPath) {
-                    await fs.promises.copyFile(rawErrorPath, path.join(resultDirPath, rawErrorFileName));
-                }
-            }
+        if (summary) {
+            const resultFileName = `${repoPrefix}.${resultFileNameSuffix}`;
+            await fs.promises.writeFile(path.join(resultDirPath, resultFileName), summary, { encoding: "utf-8" });
         }
-        finally {
-            // Throw away the repo so we don't run out of space
-            // Note that we specifically don't recover and attempt another repo if this fails
-            console.log("Cleaning up repo");
-            if (params.tmpfs) {
-                if (diagnosticOutput) {
-                    // Dump any processes holding onto the download directory in case umount fails
-                    await execAsync(processCwd, `lsof -K i | grep ${downloadDir} || true`);
-                }
-                try {
-                    await execAsync(processCwd, "sudo umount " + downloadDir);
-                }
-                catch (e) {
-                    // HACK: Sometimes the server lingers for a brief period, so retry.
-                    // Obviously, it would be better to have a way to know when it is gone-gone,
-                    // but Linux doesn't provide such a mechanism for non-child processes.
-                    // (You can poll for a process with the given PID after sending a kill signal,
-                    // but best practice is to guard against the possibility of a new process
-                    // being given the same PID.)
-                    try {
-                        console.log("umount failed - trying again after delay");
-                        await new Promise(resolve => setTimeout(resolve, 5000));
-                        await execAsync(processCwd, "sudo umount " + downloadDir);
-                    }
-                    catch {
-                        await execAsync(processCwd, `pstree -palT`);
-                        throw e;
-                    }
-                }
+
+        if (tsServerResult) {
+            const replayScriptPath = path.join(downloadDir.path, path.basename(replayScriptArtifactPath));
+            const repoDir = path.join(downloadDir.path, repo.name);
+
+            let commit: string | undefined;
+            try {
+                console.log("Extracting commit SHA for repro steps");
+                commit = (await execAsync(repoDir, `git rev-parse @`)).trim()
+            }
+            catch {
+                //noop
+            }
+
+            summaries.push({
+                tsServerResult,
+                repo,
+                oldTsEntrypointPath,
+                rawErrorArtifactPath,
+                replayScript: fs.readFileSync(replayScriptPath, { encoding: "utf-8" }).split(/\r?\n/).slice(-5).join("\n"),
+                replayScriptArtifactPath,
+                replayScriptName: path.basename(replayScriptArtifactPath),
+                commit
+            });
+        }
+
+        if (summary || tsServerResult) {
+            // In practice, there will only be a replay script when the entrypoint is tsserver
+            // There can be replay steps without a summary, but then they're not interesting
+            if (replayScriptPath) {
+                await fs.promises.copyFile(replayScriptPath, path.join(resultDirPath, replayScriptFileName));
+            }
+            if (rawErrorPath) {
+                await fs.promises.copyFile(rawErrorPath, path.join(resultDirPath, rawErrorFileName));
             }
         }
     }
@@ -859,12 +841,10 @@ export async function mainAsync(params: GitParams | UserParams): Promise<void> {
     }
 
     if (params.tmpfs) {
-        await execAsync(processCwd, "sudo rm -rf " + downloadDir);
         await execAsync(processCwd, "sudo rm -rf " + oldTscDirPath);
         await execAsync(processCwd, "sudo rm -rf " + newTscDirPath);
     }
     else {
-        await execAsync(processCwd, "rm -rf " + downloadDir);
         await execAsync(processCwd, "rm -rf " + oldTscDirPath);
         await execAsync(processCwd, "rm -rf " + newTscDirPath);
     }

--- a/src/utils/installPackages.ts
+++ b/src/utils/installPackages.ts
@@ -14,6 +14,7 @@ export enum InstallTool {
 
 export interface InstallCommand {
     directory: string;
+    prettyDirectory: string;
     tool: InstallTool;
     arguments: readonly string[];
 }
@@ -24,6 +25,8 @@ export interface InstallCommand {
  */
 export async function installPackages(repoDir: string, ignoreScripts: boolean, quietOutput: boolean, recursiveSearch: boolean, monorepoPackages?: readonly string[], types?: string[]): Promise<InstallCommand[]> {
     monorepoPackages = monorepoPackages ?? await utils.getMonorepoOrder(repoDir);
+
+    const repoName = path.basename(repoDir);
 
     const isRepoYarn = await utils.exists(path.join(repoDir, "yarn.lock"));
     // The existence of .yarnrc.yml indicates that this repo uses yarn 2
@@ -119,8 +122,11 @@ export async function installPackages(repoDir: string, ignoreScripts: boolean, q
             continue;
         }
 
+        const prettyDirectory = path.join(repoName, path.relative(repoDir, packageRoot));
+
         commands.push({
             directory: packageRoot,
+            prettyDirectory,
             tool,
             arguments: args,
         });
@@ -133,6 +139,7 @@ export async function installPackages(repoDir: string, ignoreScripts: boolean, q
 
             commands.push({
                 directory: packageRoot,
+                prettyDirectory,
                 tool: InstallTool.Npm,
                 arguments: args
             });

--- a/src/utils/overlayFS.ts
+++ b/src/utils/overlayFS.ts
@@ -1,0 +1,154 @@
+import path from "path";
+import fs from "fs";
+import { execAsync } from "./execUtils";
+
+export interface OverlayBaseFS {
+    path: string;
+    createOverlay(): Promise<OverlayMergedFS>;
+}
+
+export interface OverlayMergedFS extends AsyncDisposable {
+    path: string;
+}
+
+export interface DisposableOverlayBaseFS extends OverlayBaseFS, AsyncDisposable {}
+
+const processCwd = process.cwd();
+
+/**
+ * Creates an overlay FS using a tmpfs mount. A base directory is created on the tmpfs.
+ * New overlays are created by mounting an overlay on top of the base directory.
+ * 
+ * This requires root access.
+ */
+export async function createTempOverlayFS(root: string): Promise<DisposableOverlayBaseFS> {
+    await tryUnmount(root);
+    await retryRm(root);
+    await mkdirAll(root);
+    await execAsync(processCwd, `sudo mount -t tmpfs -o size=4g tmpfs ${root}`);
+
+    const basePath = path.join(root, "base");
+    await mkdirAll(basePath);
+
+    let overlayCount = 0;
+    let overlays: (AsyncDisposable | undefined)[] = [];
+
+    async function createOverlay(): Promise<OverlayMergedFS> {
+        const overlayId = overlayCount++;
+
+        const overlayRoot = path.join(root, `overlay-${overlayId}`);
+        const upperDir = path.join(overlayRoot, "upper");
+        const workDir = path.join(overlayRoot, "work");
+        const merged = path.join(overlayRoot, "merged");
+
+        await mkdirAll(upperDir, workDir, merged);
+
+        await execAsync(processCwd, `sudo mount -t overlay overlay -o lowerdir=${basePath},upperdir=${upperDir},workdir=${workDir} ${merged}`);
+
+        const overlay: OverlayMergedFS = {
+            path: merged,
+            [Symbol.asyncDispose]: async () => {
+                overlays[overlayId] = undefined;
+                await tryUnmount(merged);
+                await retryRm(overlayRoot);
+            }
+        }
+
+        overlays[overlayId] = overlay;
+        return overlay;
+    }
+
+    return {
+        path: basePath,
+        createOverlay,
+        [Symbol.asyncDispose]: async () => {
+            for (const overlay of overlays) {
+                if (overlay) {
+                    await overlay[Symbol.asyncDispose]();
+                }
+            }
+            await tryUnmount(root);
+            await retryRm(root);
+        },  
+    }
+}
+
+async function retry(fn: () => void | Promise<void>, retries: number, delayMs: number): Promise<void> {
+    for (let i = 0; i < retries; i++) {
+        try {
+            await fn();
+            return;
+        } catch (e) {
+            if (i === retries - 1) {
+                throw e;
+            }
+            await new Promise(resolve => setTimeout(resolve, delayMs));
+        }
+    }
+}
+
+async function tryUnmount(p: string) {
+    try {
+        await execAsync(processCwd, `sudo umount -R ${p}`)
+    } catch {
+        // ignore
+    }
+}
+
+function retryRm(p: string) {
+    return retry(() => fs.promises.rm(p, { recursive: true, force: true }), 3, 1000);
+}
+
+async function mkdirAll(...args: string[]) {
+    for (const p of args) {
+        await fs.promises.mkdir(p, { recursive: true });
+    }
+}
+
+/**
+ * Creates a fake overlay FS, which is just a directory on the local filesystem.
+ * Overlays are created by copying the contents of the `base` directory.
+ */
+export async function createCopyingOverlayFS(root: string): Promise<DisposableOverlayBaseFS> {
+    await retryRm(root);
+    await mkdirAll(root);
+
+    const basePath = path.join(root, "base");
+    await mkdirAll(basePath);
+
+    let overlayCount = 0;
+    let overlays: (AsyncDisposable | undefined)[] = [];
+
+    async function createOverlay(): Promise<OverlayMergedFS> {
+        const overlayId = overlayCount++;
+
+        const overlayRoot = path.join(root, `overlay-${overlayId}`);
+        await retryRm(overlayRoot);
+
+        await execAsync(processCwd, `cp -r ${basePath} ${overlayRoot}`);
+
+        const overlay: OverlayMergedFS = {
+            path: overlayRoot,
+            [Symbol.asyncDispose]: async () => {
+                overlays[overlayId] = undefined;
+                await retryRm(overlayRoot);
+            }
+        }
+
+        overlays[overlayId] = overlay;
+        return overlay;
+    }
+
+    return {
+        path: basePath,
+        createOverlay,
+        [Symbol.asyncDispose]: async () => {
+            for (const overlay of overlays) {
+                if (overlay) {
+                    await overlay[Symbol.asyncDispose]();
+                }
+            }
+            await retryRm(root);
+        },  
+    }
+}

--- a/src/utils/overlayFS.ts
+++ b/src/utils/overlayFS.ts
@@ -125,7 +125,7 @@ export async function createCopyingOverlayFS(root: string): Promise<DisposableOv
         const overlayRoot = path.join(root, `overlay-${overlayId}`);
         await retryRm(overlayRoot);
 
-        await execAsync(processCwd, `cp -r ${basePath} ${overlayRoot}`);
+        await execAsync(processCwd, `cp -r --reflink=auto ${basePath} ${overlayRoot}`);
 
         const overlay: OverlayMergedFS = {
             path: overlayRoot,

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -3,6 +3,7 @@ import { getTscRepoResult, downloadTsRepoAsync } from '../src/main'
 import { execSync } from "child_process"
 import { existsSync, mkdirSync } from "fs"
 import path = require("path")
+import { createCopyingOverlayFS } from '../src/utils/overlayFS'
 describe("main", () => {
     jest.setTimeout(10 * 60 * 1000)
     xit("build-only correctly caches", async () => {
@@ -15,7 +16,7 @@ describe("main", () => {
             path.resolve("./typescript-main/built/local/tsc.js"),
             path.resolve("./typescript-44585/built/local/tsc.js"),
             /*ignoreOldTscFailures*/ true, // as in a user test
-            "./ts_downloads",
+            await createCopyingOverlayFS("./ts_downloads"),
             /*diagnosticOutput*/ false)
         expect(status).toEqual("NewBuildHadErrors")
         expect(summary).toBeDefined()


### PR DESCRIPTION
Currently, we install a repo, then run TS on it, then run TS on it again. This creates a situation where the results of the first compile can negatively affect the second.

In #131, I attempted to fix this by using git to stage all files after installing (even if ignored), then reverting them. That didn't work because FS/memory cost of that was too high for the runner.

Instead, we can use OverlayFS to do this; we install into the lower layer, then perform all operations on an upper layer. After the first run, we throw away the overlay and create a new one, such that the second compilation sees the repo as being freshly installed.

If tmpfs is disabled, we instead use multiple directories and just reflink copy them. Theoretically we could use copying within the tmpfs too, but I don't believe that tmpfs can do that.

This PR is best viewed without whitespace due to indent changes: https://github.com/microsoft/typescript-error-deltas/pull/143/files?w=1