### PR TITLE
Fix azure-sdk, consider stderr when processing errors

### DIFF
--- a/src/listUserTestRepos.ts
+++ b/src/listUserTestRepos.ts
@@ -14,7 +14,18 @@ const userTestsDir = argv[2];
 const outputPath = argv[3];
 
 try {
-    const repos = getUserTestsRepos(userTestsDir);
+    const repos = getUserTestsRepos(userTestsDir).filter(r => {
+        // TODO(jakebailey): revert me
+        switch (r.name) {
+            case "azure-sdk":
+            case "follow-redirects":
+            case "puppeteer":
+            case "pyright":
+                return true;
+            default:
+                return false;
+        }
+    });
     fs.writeFileSync(outputPath, JSON.stringify(repos), { encoding: "utf-8" });
 }
 catch (err) {

--- a/src/listUserTestRepos.ts
+++ b/src/listUserTestRepos.ts
@@ -14,18 +14,7 @@ const userTestsDir = argv[2];
 const outputPath = argv[3];
 
 try {
-    const repos = getUserTestsRepos(userTestsDir).filter(r => {
-        // TODO(jakebailey): revert me
-        switch (r.name) {
-            case "azure-sdk":
-            case "follow-redirects":
-            case "puppeteer":
-            case "pyright":
-                return true;
-            default:
-                return false;
-        }
-    });
+    const repos = getUserTestsRepos(userTestsDir);
     fs.writeFileSync(outputPath, JSON.stringify(repos), { encoding: "utf-8" });
 }
 catch (err) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,6 +84,7 @@ export type RepoStatus =
     | "Language service disabled in new TS"
     | "Detected interesting changes"
     | "Detected no interesting changes"
+    | "Timeout"
     ;
 
 interface TSServerResult {
@@ -680,6 +681,9 @@ export async function getTscRepoResult(
     }
     catch (err) {
         reportError(err, `Error building ${repo.url ?? repo.name}`);
+        if (err instanceof ge.TimeoutError) {
+            return { status: "Timeout" };
+        }
         return { status: "Unknown failure" };
     }
     finally {

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,7 @@ export type TsEntrypoint = "tsc" | "tsserver";
 
 const processCwd = process.cwd();
 const packageTimeout = 10 * 60 * 1000;
-const executionTimeout = 10 * 60 * 1000;
+const executionTimeout = 20 * 60 * 1000;
 
 const prng = randomSeed.create();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,7 @@ export type TsEntrypoint = "tsc" | "tsserver";
 
 const processCwd = process.cwd();
 const packageTimeout = 10 * 60 * 1000;
-const executionTimeout = 50 * 60 * 1000;
+const executionTimeout = 10 * 60 * 1000;
 
 const prng = randomSeed.create();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,7 @@ export type TsEntrypoint = "tsc" | "tsserver";
 
 const processCwd = process.cwd();
 const packageTimeout = 10 * 60 * 1000;
-const executionTimeout = 20 * 60 * 1000;
+const executionTimeout = 30 * 60 * 1000;
 
 const prng = randomSeed.create();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,7 @@ export type TsEntrypoint = "tsc" | "tsserver";
 
 const processCwd = process.cwd();
 const packageTimeout = 10 * 60 * 1000;
-const executionTimeout = 30 * 60 * 1000;
+const executionTimeout = 50 * 60 * 1000;
 
 const prng = randomSeed.create();
 

--- a/src/utils/getTscErrors.ts
+++ b/src/utils/getTscErrors.ts
@@ -79,7 +79,8 @@ export async function buildAndGetErrors(repoDir: string, monorepoPackages: reado
             if (!spawnResult) {
                 throw new Error(`build.sh timed out after ${timeoutMs} ms`);
             }
-            console.log(`${buildScriptPath} took ${Math.round(performance.now() - before)} ms`)
+            console.log(`${buildScriptPath} took ${Math.round(performance.now() - before)} ms`);
+            console.log(spawnResult.stderr);
 
             const { isEmpty, stdout, hasBuildFailure } = getBuildSummary(spawnResult, /*mergeOutputs*/ true);
 

--- a/src/utils/getTscErrors.ts
+++ b/src/utils/getTscErrors.ts
@@ -80,7 +80,7 @@ export async function buildAndGetErrors(repoDir: string, monorepoPackages: reado
                 throw new Error(`build.sh timed out after ${timeoutMs} ms`);
             }
             console.log(`${buildScriptPath} took ${Math.round(performance.now() - before)} ms`);
-            console.log(spawnResult.stderr);
+            // console.log(spawnResult.stderr);
 
             const { isEmpty, stdout, hasBuildFailure } = getBuildSummary(spawnResult, /*mergeOutputs*/ true);
 

--- a/src/utils/getTscErrors.ts
+++ b/src/utils/getTscErrors.ts
@@ -80,7 +80,6 @@ export async function buildAndGetErrors(repoDir: string, monorepoPackages: reado
                 throw new Error(`build.sh timed out after ${timeoutMs} ms`);
             }
             console.log(`${buildScriptPath} took ${Math.round(performance.now() - before)} ms`);
-            console.log(spawnResult.stderr);
 
             const { isEmpty, stdout, hasBuildFailure } = getBuildSummary(spawnResult, /*mergeOutputs*/ true);
 

--- a/src/utils/getTscErrors.ts
+++ b/src/utils/getTscErrors.ts
@@ -77,7 +77,7 @@ export async function buildAndGetErrors(repoDir: string, monorepoPackages: reado
             const before = performance.now();
             const spawnResult = await spawnWithTimeoutAsync(repoDir, path.resolve(buildScriptPath), [], timeoutMs, { ...process.env, TS: tsRepoPath });
             if (!spawnResult) {
-                throw new Error(`build.sh timed out after ${timeoutMs} ms`);
+                throw new TimeoutError(`build.sh timed out after ${timeoutMs} ms`);
             }
             console.log(`${buildScriptPath} took ${Math.round(performance.now() - before)} ms`);
 
@@ -221,4 +221,10 @@ function getBuildSummary({ code, signal, stderr, stdout }: SpawnResult, mergeOut
         hasBuildFailure: !!(code || signal || (stderr && stderr.length && !stderr.match(/debugger/i))), // --inspect prints the debug port to stderr
         isEmpty: !!stdout.match(/TS18003/)
     };
+}
+
+export class TimeoutError extends Error {
+    constructor(message: string) {
+        super(message);
+    }
 }

--- a/src/utils/getTscErrors.ts
+++ b/src/utils/getTscErrors.ts
@@ -74,12 +74,14 @@ export async function buildAndGetErrors(repoDir: string, monorepoPackages: reado
         const buildScriptPath = path.join(repoDir, "build.sh");
         if (fs.existsSync(buildScriptPath)) {
 
+            const before = performance.now();
             const spawnResult = await spawnWithTimeoutAsync(repoDir, path.resolve(buildScriptPath), [], timeoutMs, { ...process.env, TS: tsRepoPath });
             if (!spawnResult) {
                 throw new Error(`build.sh timed out after ${timeoutMs} ms`);
             }
+            console.log(`${buildScriptPath} took ${Math.round(performance.now() - before)} ms`)
 
-            const { isEmpty, stdout, hasBuildFailure } = getBuildSummary(spawnResult);
+            const { isEmpty, stdout, hasBuildFailure } = getBuildSummary(spawnResult, /*mergeOutputs*/ true);
 
             if (!isEmpty) {
                 projectErrors.push(await getProjectErrors(buildScriptPath, tsRepoPath, stdout, hasBuildFailure, /*isComposite*/ false, /*reportGithubLinks*/ false));
@@ -209,7 +211,11 @@ function getLocalErrorFromLine(line: string, projectUrl: string): LocalError | u
     return undefined;
 }
 
-function getBuildSummary({ code, signal, stderr, stdout }: SpawnResult) {
+function getBuildSummary({ code, signal, stderr, stdout }: SpawnResult, mergeOutputs?: boolean) {
+    if (mergeOutputs) {
+        stdout = stdout + "\n" + stderr;
+    }
+
     return {
         stdout,
         hasBuildFailure: !!(code || signal || (stderr && stderr.length && !stderr.match(/debugger/i))), // --inspect prints the debug port to stderr

--- a/src/utils/getTscErrors.ts
+++ b/src/utils/getTscErrors.ts
@@ -80,7 +80,7 @@ export async function buildAndGetErrors(repoDir: string, monorepoPackages: reado
                 throw new Error(`build.sh timed out after ${timeoutMs} ms`);
             }
             console.log(`${buildScriptPath} took ${Math.round(performance.now() - before)} ms`);
-            // console.log(spawnResult.stderr);
+            console.log(spawnResult.stderr);
 
             const { isEmpty, stdout, hasBuildFailure } = getBuildSummary(spawnResult, /*mergeOutputs*/ true);
 

--- a/userTests/azure-sdk/build.sh
+++ b/userTests/azure-sdk/build.sh
@@ -1,5 +1,5 @@
 set -x
-command -v rush &> /dev/null || npm install -g @microsoft/rush
+command -v rush || npm install -g @microsoft/rush
 rm -rf azure-sdk
 git clone --depth 1 https://github.com/Azure/azure-sdk-for-js.git azure-sdk
 cd azure-sdk

--- a/userTests/azure-sdk/build.sh
+++ b/userTests/azure-sdk/build.sh
@@ -20,6 +20,10 @@ cd $START
 # The monorepo contains loads of other packages which make the build too slow for the tester.
 RUSH_JSON=$(mktemp)
 npx json5 rush.json > $RUSH_JSON
-node -e 'for (const x of JSON.parse(fs.readFileSync(process.argv[1], "utf8")).projects) { if (x.versionPolicyName === "client") console.log("--to", x.packageName)}' $RUSH_JSON \
-    | xargs -x rush rebuild
+node -e '
+for (const x of JSON.parse(fs.readFileSync(process.argv[1], "utf8")).projects) {
+    if (x.packageName.startsWith("@azure/") && x.versionPolicyName === "client") {
+        console.log("--to", x.packageName);
+    }
+}' $RUSH_JSON | xargs -x rush rebuild
 rm $RUSH_JSON

--- a/userTests/azure-sdk/build.sh
+++ b/userTests/azure-sdk/build.sh
@@ -18,7 +18,8 @@ cd $START
 
 # Limit the build to just those packages that are "client" libraries consumed by downstream users.
 # The monorepo contains loads of other packages which make the build too slow for the tester.
-ARGS=$(node -e 'for (const x of JSON.parse(fs.readFileSync(process.argv[1], "utf8")).projects) { if (x.versionPolicyName === "client") console.log(`--to ${x.packageName}`)}' <(npx json5 rush.json))
-ARGS=( $ARGS )
-
-rush rebuild "${ARGS[@]}"
+RUSH_JSON=$(mktemp)
+npx json5 rush.json > $RUSH_JSON
+node -e 'for (const x of JSON.parse(fs.readFileSync(process.argv[1], "utf8")).projects) { if (x.versionPolicyName === "client") console.log("--to", x.packageName)}' $RUSH_JSON \
+    | xargs -x rush rebuild
+rm $RUSH_JSON

--- a/userTests/azure-sdk/build.sh
+++ b/userTests/azure-sdk/build.sh
@@ -1,5 +1,5 @@
 set -x
-command -v rush || npm install -g @microsoft/rush
+npm install -g @microsoft/rush
 rm -rf azure-sdk
 git clone --depth 1 https://github.com/Azure/azure-sdk-for-js.git azure-sdk
 cd azure-sdk

--- a/userTests/azure-sdk/build.sh
+++ b/userTests/azure-sdk/build.sh
@@ -15,4 +15,10 @@ cd $START/common/temp/node_modules/.pnpm/typescript@$LOCAL_TS/node_modules
 rm -rf typescript
 ln -s $TS ./typescript
 cd $START
-rush rebuild
+
+# Limit the build to just those packages that are "client" libraries consumed by downstream users.
+# The monorepo contains loads of other packages which make the build too slow for the tester.
+ARGS=$(node -e 'for (const x of JSON.parse(fs.readFileSync(process.argv[1], "utf8")).projects) { if (x.versionPolicyName === "client") console.log(`--to ${x.packageName}`)}' <(npx json5 rush.json))
+ARGS=( $ARGS )
+
+rush rebuild "${ARGS[@]}"

--- a/userTests/azure-sdk/build.sh
+++ b/userTests/azure-sdk/build.sh
@@ -16,14 +16,25 @@ rm -rf typescript
 ln -s $TS ./typescript
 cd $START
 
-# Limit the build to just those packages that are "client" libraries consumed by downstream users.
-# The monorepo contains loads of other packages which make the build too slow for the tester.
-RUSH_JSON=$(mktemp)
-npx json5 rush.json > $RUSH_JSON
-node -e '
-for (const x of JSON.parse(fs.readFileSync(process.argv[1], "utf8")).projects) {
-    if (x.packageName.startsWith("@azure/") && x.versionPolicyName === "client") {
-        console.log("--to", x.packageName);
-    }
-}' $RUSH_JSON | xargs -x rush rebuild
-rm $RUSH_JSON
+# Running everything takes a long time; just build the top 20 client packages by downloads.
+rush rebuild \
+    --to @azure/identity \
+    --to @azure/storage-blob \
+    --to @azure/keyvault-keys \
+    --to @azure/opentelemetry-instrumentation-azure-sdk \
+    --to @azure/cosmos \
+    --to @azure/keyvault-secrets \
+    --to @azure/service-bus \
+    --to @azure/openai \
+    --to @azure/app-configuration \
+    --to @azure/storage-queue \
+    --to @azure/storage-file-share \
+    --to @azure/event-hubs \
+    --to @azure/communication-common \
+    --to @azure/data-tables \
+    --to @azure/storage-file-datalake \
+    --to @azure/search-documents \
+    --to @azure/web-pubsub-client \
+    --to @azure/maps-common \
+    --to @azure/ai-form-recognizer \
+    --to @azure/communication-email

--- a/userTests/azure-sdk/build.sh
+++ b/userTests/azure-sdk/build.sh
@@ -1,16 +1,18 @@
-npm install -g @microsoft/rush
+set -x
+command -v rush &> /dev/null || npm install -g @microsoft/rush
 rm -rf azure-sdk
 git clone --depth 1 https://github.com/Azure/azure-sdk-for-js.git azure-sdk
 cd azure-sdk
 START=$(pwd)
 rush update
-cd sdk/core/core-http
+cd sdk/core/core-util
 # Sync up all TS versions used internally so they're all linked from a known location
-rush add -p "typescript@3.5.1" --dev -m
+LOCAL_TS=$(node -e 'console.log(JSON.parse(fs.readFileSync("node_modules/typescript/package.json", "utf8")).version)')
+rush add -p "typescript@$LOCAL_TS" --dev -m
 # -nervous laugh-
 # Relink installed TSes to built TS
-cd $START/common/temp/node_modules/.pnpm/typescript@3.5.1/node_modules
+cd $START/common/temp/node_modules/.pnpm/typescript@$LOCAL_TS/node_modules
 rm -rf typescript
 ln -s $TS ./typescript
 cd $START
-rush rebuild --parallelism 1
+rush rebuild

--- a/userTests/typescript-eslint/build.sh
+++ b/userTests/typescript-eslint/build.sh
@@ -1,6 +1,6 @@
 set -x
 
-command -v yarn &> /dev/null || npm i -g yarn
+npm i -g yarn
 rm -rf typescript-eslint
 git clone --depth 1 https://github.com/typescript-eslint/typescript-eslint.git typescript-eslint
 cd typescript-eslint


### PR DESCRIPTION
This fixed the azure-sdk test by updating it and making it only test the top 20 downloaded packages (as of today).

Also, consider stderr when processing build.sh errors; since we're running someone else's build systems, there's no way to know where they might print things (whereas for other tests we're running tsc directly and we know that the errors will always be on stdout).