### PR TITLE
Run more repos by default, move the NewErrors task earlier.

### DIFF
--- a/azure-pipelines-gitTests-template.yml
+++ b/azure-pipelines-gitTests-template.yml
@@ -10,7 +10,7 @@ parameters:
   - name: REPO_COUNT
     displayName: Repo Count
     type: number
-    default: 200
+    default: 300
   - name: REPO_START_INDEX
     displayName: Repo Start Index
     type: number

--- a/azure-pipelines-gitTests.yml
+++ b/azure-pipelines-gitTests.yml
@@ -10,7 +10,7 @@ parameters:
   - name: REPO_COUNT
     displayName: Repo Count
     type: number
-    default: 200
+    default: 800
   - name: REPO_START_INDEX
     displayName: Repo Start Index
     type: number
@@ -53,7 +53,7 @@ parameters:
     default: 'n/a'
 
 schedules:
-  - cron: "0 18 * * Sun" # time is in UTC
+  - cron: "0 17 * * Sun" # time is in UTC
     displayName: Sunday overnight run
     always: true
     branches:


### PR DESCRIPTION
This PR should get the Sunday run to:

1. Run 300 server tests on TS and JS each
2. Run 800 compiler tests
3. Run the compiler tests a smidge earlier (I think, someone check my cron)