### PR TITLE
Don't hide typescript.js from stack traces

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -980,7 +980,7 @@ ${filter ? filterToTsserverLines(errorObj.message) : errorObj.message}`;
 }
 
 function filterToTsserverLines(stackLines: string): string {
-    const tsserverRegex = /^.*tsserver\.js.*$/mg;
+    const tsserverRegex = /^.*(?:tsserver|typescript)\.js.*$/mg;
     let tsserverLines = "";
     let match;
     while (match = tsserverRegex.exec(stackLines)) {


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/pull/55326 made `tsserver.js` use `typescript.js`; this broke stack trace filtering.

I'm not 100% certain why we need this filtering at all but this will at least unbreak it.