### PR TITLE
Let OS choose tmpfs size

### DIFF
--- a/src/utils/overlayFS.ts
+++ b/src/utils/overlayFS.ts
@@ -24,7 +24,7 @@ export async function createTempOverlayFS(root: string, diagnosticOutput: boolea
     await tryUnmount(root);
     await rmWithRetryAsRoot(root);
     await mkdirAllAsRoot(root);
-    await execAsync(processCwd, `sudo mount -t tmpfs -o size=4g tmpfs ${root}`);
+    await execAsync(processCwd, `sudo mount -t tmpfs tmpfs ${root}`);
 
     const lowerDir = path.join(root, "base");
     await mkdirAll(lowerDir);

--- a/src/utils/overlayFS.ts
+++ b/src/utils/overlayFS.ts
@@ -1,3 +1,4 @@
+import fs from "fs";
 import path from "path";
 import { execAsync } from "./execUtils";
 
@@ -99,10 +100,12 @@ async function retry(fn: (() => void) | (() => Promise<void>), retries: number, 
 }
 
 async function tryUnmount(p: string) {
+    if (!fs.existsSync(p)) return;
     try {
         await execAsync(processCwd, `sudo umount -R ${p}`)
     } catch {
-        // ignore
+        // Print out handles for debugging.
+        await execAsync(processCwd, `sudo lsof ${p}`)
     }
 }
 


### PR DESCRIPTION
Some of the overnight jobs are failing because they fill up the 4GB tmpfs. If we don't specify the size, the OS will just use up to half of the machine memory; that will scale better with the machines that use this feature.