### PR TITLE
Add unit test to mainAsync

### DIFF
--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`main outputs server errors 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      "/mnt/q/Repos/typescript-error-deltas/ts_downloads/base/MockRepoOwner.MockRepoName.rawError.txt",
+      "Req #123 - completionInfo
+Some error. Could not do something. 
+Maybe a Debug fail.
+    at a (/mnt/vss/_work/1/s/typescript-1.1.1/lib/typescript.js:1:1)
+    at b (/mnt/vss/_work/1/s/typescript-1.1.1/lib/typescript.js:2:2)
+    at c (/mnt/vss/_work/1/s/typescript-1.1.1/lib/typescript.js:3:3)
+    at d (/mnt/vss/_work/1/s/typescript-1.1.1/lib/typescript.js:4:4)
+    at e (/mnt/vss/_work/1/s/typescript-1.1.1/lib/typescript.js:5:5)",
+    ],
+    [
+      "/mnt/q/Repos/typescript-error-deltas/artifacts/718e48b799650d4b66e5d80ad6bac7b9.results.txt",
+      "<h2>Maybe a Debug fail.</h2>
+
+\`\`\`
+Req #123 - completionInfo
+    at a (/mnt/vss/_work/1/s/typescript-1.1.1/lib/typescript.js:1:1)
+    at b (/mnt/vss/_work/1/s/typescript-1.1.1/lib/typescript.js:2:2)
+    at c (/mnt/vss/_work/1/s/typescript-1.1.1/lib/typescript.js:3:3)
+    at d (/mnt/vss/_work/1/s/typescript-1.1.1/lib/typescript.js:4:4)
+    at e (/mnt/vss/_work/1/s/typescript-1.1.1/lib/typescript.js:5:5)
+\`\`\`
+
+<h4>Affected repos</h4>
+<details>
+<summary><a href="https://github.com/MockRepoOwner/MockRepoName">MockRepoOwner/MockRepoName</a></summary>
+Raw error text: <code>artifacts/MockRepoOwner.MockRepoName.rawError.txt</code> in the <a href="PLACEHOLDER_ARTIFACT_FOLDER">artifact folder</a>
+<h4>Last few requests</h4>
+
+\`\`\`json
+{"rootDirPlaceholder":"@PROJECT_ROOT@","serverArgs":["--disableAutomaticTypingAcquisition"]}
+{"seq":1,"type":"request","command":"configure","arguments":{"preferences":{"disableLineTextInReferences":true,"includePackageJsonAutoImports":"auto","includeCompletionsForImportStatements":true,"includeCompletionsWithSnippetText":true,"includeAutomaticOptionalChainCompletions":true,"includeCompletionsWithInsertText":true,"includeCompletionsWithClassMemberSnippets":true,"allowIncompleteCompletions":true,"includeCompletionsForModuleExports":false},"watchOptions":{"excludeDirectories":["**/node_modules"]}}}
+{"seq":2,"type":"request","command":"updateOpen","arguments":{"changedFiles":[],"closedFiles":[],"openFiles":[{"file":"@PROJECT_ROOT@/sample_repoName.config.js","projectRootPath":"@PROJECT_ROOT@"}]}}
+{"seq":3,"type":"request","command":"completionInfo","arguments":{"file":"@PROJECT_ROOT@/src/sampleTsFile.ts","line":1,"offset":1,"includeExternalModuleExports":false,"triggerKind":1}}
+\`\`\`
+
+<h4>Repro steps</h4>
+<ol>
+<li><code>git clone https://github.com/MockRepoOwner/MockRepoName --recurse-submodules</code></li>
+<li>In dir <code>MockRepoName</code>, run <code>git reset --hard 57b462387e88aa7e363af0daf867a5dc1e83a935</code></li>
+<li><details><summary>Install packages (exact steps are below, but it might be easier to follow the repo readme)</summary><ol>
+  <li>In dir <code>dirA</code>, run <code>npm --prefer-offline --no-audit --no-progress --legacy-peer-deps --ignore-scripts -q</code></li>
+  <li>In dir <code>dirB/dirC</code>, run <code>npm --prefer-offline --no-audit --no-progress --legacy-peer-deps --ignore-scripts -q</code></li>
+  <li>In dir <code>dirD/dirE/dirF</code>, run <code>npm --prefer-offline --no-audit --no-progress --legacy-peer-deps --ignore-scripts -q</code></li>
+</ol></details>
+<li>Back in the initial folder, download <code>artifacts/MockRepoOwner.MockRepoName.replay.txt</code> from the <a href="PLACEHOLDER_ARTIFACT_FOLDER">artifact folder</a></li>
+<li><code>npm install --no-save @typescript/server-replay</code></li>
+<li><code>npx tsreplay ./MockRepoName ./MockRepoOwner.MockRepoName.replay.txt path/to/tsserver.js</code></li>
+<li><code>npx tsreplay --help</code> to learn about helpful switches for debugging, logging, etc</li>
+</ol>
+</details>
+",
+      {
+        "encoding": "utf-8",
+      },
+    ],
+    [
+      "/mnt/q/Repos/typescript-error-deltas/artifacts/metadata.json",
+      "{"newTsResolvedVersion":"1.1.1","oldTsResolvedVersion":"0.0.0","statusCounts":{"Detected interesting changes":1}}",
+      {
+        "encoding": "utf-8",
+      },
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+    {
+      "type": "return",
+      "value": undefined,
+    },
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,11 +1,128 @@
-/// <reference types="jest" />
-import { getTscRepoResult, downloadTsRepoAsync } from '../src/main'
+import { getTscRepoResult, downloadTsRepoAsync, mainAsync } from '../src/main'
 import { execSync } from "child_process"
-import { existsSync, mkdirSync } from "fs"
+import * as fs from 'fs';
 import path = require("path")
 import { createCopyingOverlayFS } from '../src/utils/overlayFS'
+
+jest.mock('random-seed', () => {
+    return {
+        create: () => {
+            return {
+                random: () => 1,
+                seed: () => { },
+                string: () => ''
+            };
+        },
+    };
+});
+jest.mock("../src/utils/packageUtils", () => {
+    return {
+        exists: jest.fn().mockResolvedValue(true),
+        getMonorepoOrder: jest.fn().mockResolvedValue([
+            "./dirA/package.json",
+            "./dirB/dirC/package.json",
+            "./dirD/DirE/dirF/package.json"
+        ])
+    };
+});
+jest.mock("../src/utils/execUtils", () => {
+    return {
+        spawnWithTimeoutAsync: jest.fn((cwd: string, command: string, args: readonly string[], timeoutMs: number, env?: {}) => {
+            if (command === 'npm') {
+                // Return nothing so that npm install appears successfull.
+                return {};
+            }
+
+            return {
+                stdout: JSON.stringify({
+                    "request_seq": "123",
+                    "command": "completionInfo",
+                    "message": "Some error. Could not do something. \nMaybe a Debug fail.\n    at a (/mnt/vss/_work/1/s/typescript-1.1.1/lib/typescript.js:1:1)\n    at b (/mnt/vss/_work/1/s/typescript-1.1.1/lib/typescript.js:2:2)\n    at c (/mnt/vss/_work/1/s/typescript-1.1.1/lib/typescript.js:3:3)\n    at d (/mnt/vss/_work/1/s/typescript-1.1.1/lib/typescript.js:4:4)\n    at e (/mnt/vss/_work/1/s/typescript-1.1.1/lib/typescript.js:5:5)"
+                }),
+                stderr: '',
+                code: 5,
+                signal: null,
+
+            }
+        }),
+        execAsync: async (cwd: string, command: string) => {
+            if (command.startsWith('npm pack typescript@latest')) {
+                return ' typescript-0.0.0.tgz';
+            } else if (command.startsWith('npm pack typescript@next')) {
+                return ' typescript-1.1.1.tgz';
+            } else if (command.startsWith('git rev-parse')) {
+                return '57b462387e88aa7e363af0daf867a5dc1e83a935';
+            }
+
+            return '';
+        }
+    }
+});
+jest.mock('fs', () => {
+    const realFs = jest.requireActual('fs');
+    const replayMock = '{\"rootDirPlaceholder\":\"@PROJECT_ROOT@\",\"serverArgs\":[\"--disableAutomaticTypingAcquisition\"]}\r\n{\"seq\":1,\"type\":\"request\",\"command\":\"configure\",\"arguments\":{\"preferences\":{\"disableLineTextInReferences\":true,\"includePackageJsonAutoImports\":\"auto\",\"includeCompletionsForImportStatements\":true,\"includeCompletionsWithSnippetText\":true,\"includeAutomaticOptionalChainCompletions\":true,\"includeCompletionsWithInsertText\":true,\"includeCompletionsWithClassMemberSnippets\":true,\"allowIncompleteCompletions\":true,\"includeCompletionsForModuleExports\":false},\"watchOptions\":{\"excludeDirectories\":[\"**/node_modules\"]}}}\r\n{\"seq\":2,\"type\":\"request\",\"command\":\"updateOpen\",\"arguments\":{\"changedFiles\":[],\"closedFiles\":[],\"openFiles\":[{\"file\":\"@PROJECT_ROOT@/sample_repoName.config.js\",\"projectRootPath\":\"@PROJECT_ROOT@\"}]}}\r\n{\"seq\":3,\"type\":\"request\",\"command\":\"completionInfo\",\"arguments\":{\"file\":\"@PROJECT_ROOT@/src/sampleTsFile.ts\",\"line\":1,\"offset\":1,\"includeExternalModuleExports\":false,\"triggerKind\":1}}';
+
+    return {
+        promises: {
+            writeFile: jest.fn(),
+            copyFile: jest.fn(),
+            rename: jest.fn().mockResolvedValue(undefined),
+        },
+        readFileSync: (path: string) => {
+            if (path.endsWith("replay.txt")) {
+                return replayMock;
+
+            } else if (path.endsWith('repos.json')) {
+                return JSON.stringify([{
+                    "url": "https://github.com/MockRepoOwner/MockRepoName",
+                    "name": "MockRepoName",
+                    "owner": "MockRepoOwner"
+                }]);
+            }
+        }
+    }
+})
+jest.mock('../src/utils/installPackages', () => {
+    const realIp = jest.requireActual('../src/utils/installPackages')
+    const npmCommand = {
+        tool: 'npm',
+        arguments: [
+            '--prefer-offline',
+            '--no-audit',
+            '--no-progress',
+            '--legacy-peer-deps',
+            '--ignore-scripts',
+            '-q',
+        ]
+    };
+
+    return {
+        InstallTool: realIp.InstallTool,
+        installPackages: async () => {
+            return [
+                {
+                    ...npmCommand,
+                    directory: './dirA',
+                    prettyDirectory: 'dirA',
+                },
+                {
+                    ...npmCommand,
+                    directory: './dirB/dirC',
+                    prettyDirectory: 'dirB/dirC',
+                },
+                {
+                    ...npmCommand,
+                    directory: './dirD/dirE/dirF',
+                    prettyDirectory: 'dirD/dirE/dirF',
+                }
+            ]
+        }
+    }
+});
+
 describe("main", () => {
-    jest.setTimeout(10 * 60 * 1000)
+    jest.setTimeout(10 * 60 * 1000);
+
     xit("build-only correctly caches", async () => {
         const { status, summary } = await getTscRepoResult(
             {
@@ -22,14 +139,34 @@ describe("main", () => {
         expect(summary).toBeDefined()
         expect(summary!.startsWith(`# [TypeScript-Node-Starter](https://github.com/Microsoft/TypeScript-Node-Starter.git)`)).toBeTruthy()
         expect(summary!.includes("- \`error TS2496: The 'arguments' object cannot be referenced in an arrow function in ES3 and ES5. Consider using a standard function expression.\`")).toBeTruthy()
-    })
+    });
+
     it("downloads from a branch", async () => {
-        if (!existsSync("./testDownloads/main")) {
-            mkdirSync("./testDownloads/main", { recursive: true });
+        if (!fs.existsSync("./testDownloads/main")) {
+            fs.mkdirSync("./testDownloads/main", { recursive: true });
         }
-        else if (existsSync("./testDownloads/main/typescript-test-fake-error")) {
+        else if (fs.existsSync("./testDownloads/main/typescript-test-fake-error")) {
             execSync("cd ./testDownloads/main/typescript-test-fake-error && git restore . && cd ..")
         }
         await downloadTsRepoAsync('./testDownloads/main', 'https://github.com/sandersn/typescript', 'test-fake-error', 'tsc')
-    })
+    });
+
+    it("outputs server errors", async () => {
+        await mainAsync({
+            testType: "github",
+            tmpfs: false,
+            entrypoint: 'tsserver',
+            diagnosticOutput: false,
+            buildWithNewWhenOldFails: false,
+            repoListPath: "./artifacts/repos.json",
+            workerCount: 1,
+            workerNumber: 1,
+            oldTsNpmVersion: 'latest',
+            newTsNpmVersion: 'next',
+            resultDirName: './artifacts',
+            prngSeed: 'testSeed',
+        });
+
+        expect(fs.promises.writeFile).toMatchSnapshot();
+    });
 })


### PR DESCRIPTION
Adds a simple unit test for the `mainAsync` function.  

Mostly mocks the dependencies on the file system and utility modules. This allows to easily test the `mainAsync` with a snapshot during local development.

Please note that I was not able to accurately verify that this is the expected result. I appreciate if any reviewer put special emphasis on the accuracy of the output.