### PR TITLE
Remove manual repro steps for a bash script

### DIFF
--- a/azure-pipelines-gitTests-template.yml
+++ b/azure-pipelines-gitTests-template.yml
@@ -91,7 +91,7 @@ jobs:
   - script: |
       npm ci
       npm run build
-      node dist/postGithubIssue ${{ parameters.ENTRYPOINT }} ${{ parameters.LANGUAGE }} ${{ parameters.REPO_COUNT }} ${{ parameters.REPO_START_INDEX }} '$(Pipeline.Workspace)' '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)' '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=artifacts&type=publishedArtifacts' ${{ parameters.POST_RESULT }}
+      node dist/postGithubIssue ${{ parameters.ENTRYPOINT }} ${{ parameters.LANGUAGE }} ${{ parameters.REPO_COUNT }} ${{ parameters.REPO_START_INDEX }} '$(Pipeline.Workspace)' '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)' '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=artifacts&type=publishedArtifacts' ${{ parameters.POST_RESULT }} '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_apis/build/builds/$(Build.BuildId)/artifacts'
     displayName: 'Create issue from new errors'
     env:
       GITHUB_PAT: $(GITHUB_PAT)

--- a/src/main.ts
+++ b/src/main.ts
@@ -452,36 +452,55 @@ Raw error text: <code>${summary.rawErrorArtifactPath}</code> in the <a href="${a
 ${summary.replayScript}
 \`\`\`
 
-<h4>Repro steps</h4>
+<h4>Repro steps</h4>`;
 
-\`\`\`bash
-`;
+        let proseSteps = `<ol>\n`;
+        let bashScript = `<h5>Bash script</h5>
+
+\`\`\`bash\n`;
+
         // No url means is user test repo
         if (!summary.repo.url) {
-            text += `# Manually download user test \`${summary.repo.name}\`\n`;
+            proseSteps += `<li>Download user test <code>${summary.repo.name}</code></li>\n`;
+            bashScript += `# Manually download user test \`${summary.repo.name}\`\n`;
         }
         else {
-            text += `git clone ${summary.repo.url} --recurse-submodules\n`;
+            proseSteps += `<li><code>git clone ${summary.repo.url} --recurse-submodules</code></li>\n`;
+            bashScript += `git clone ${summary.repo.url} --recurse-submodules\n`;
 
             if (summary.commit) {
-                text += `git -C "./${summary.repo.name}" reset --hard ${summary.commit}\n`;
+                proseSteps += `<li>In dir <code>${summary.repo.name}</code>, run <code>git reset --hard ${summary.commit}</code></li>\n`;
+                bashScript += `git -C "./${summary.repo.name}" reset --hard ${summary.commit}\n`;
             }
         }
 
         if (summary.tsServerResult.installCommands.length > 1) {
-            text += "# Install packages (exact steps are below, but it might be easier to follow the repo readme)\n";
+            proseSteps += "<li><details><summary>Install packages (exact steps are below, but it might be easier to follow the repo readme)</summary><ol>\n";
+            bashScript += "# Install packages (exact steps are below, but it might be easier to follow the repo readme)\n";
         }
         for (const command of summary.tsServerResult.installCommands) {
+            proseSteps += `  <li>In dir <code>${command.prettyDirectory}</code>, run <code>${command.tool} ${command.arguments.join(" ")}</code></li>\n`;
             const workingDirFlag = command.tool === ip.InstallTool.Npm
                 ? "--prefix"
                 : command.tool === ip.InstallTool.Yarn
                     ? "--cwd"
                     : "--dir"; // pnpm
 
-            text += `${command.tool} ${workingDirFlag} "${command.directory}" ${command.arguments.join(" ")}\n`;
+            bashScript += `${command.tool} ${workingDirFlag} "${command.directory}" ${command.arguments.join(" ")}\n`;
+        }
+        if (summary.tsServerResult.installCommands.length > 1) {
+            proseSteps += "</ol></details>\n";
         }
 
-        text += `downloadUrl=$(curl -s "${getArtifactsApiUrlPlaceholder}?artifactName=${summary.resultDirName}&api-version=7.0" | jq -r ".resource.downloadUrl")
+        // The URL of the artifact can be determined via AzDO REST APIs, but not until after the artifact is published
+        proseSteps += `<li>Back in the initial folder, download <code>${summary.replayScriptArtifactPath}</code> from the <a href="${artifactFolderUrlPlaceholder}">artifact folder</a></li>
+<li><code>npm install --no-save @typescript/server-replay</code></li>
+<li><code>npx tsreplay ./${summary.repo.name} ./${summary.replayScriptName} path/to/tsserver.js</code></li>
+<li><code>npx tsreplay --help</code> to learn about helpful switches for debugging, logging, etc</li>
+</ol>
+`;
+
+        bashScript += `downloadUrl=$(curl -s "${getArtifactsApiUrlPlaceholder}?artifactName=${summary.resultDirName}&api-version=7.0" | jq -r ".resource.downloadUrl")
 wget -O ${summary.resultDirName}.zip "$downloadUrl"
 unzip -p ${summary.resultDirName}.zip ${summary.resultDirName}/${summary.replayScriptName} > ${summary.replayScriptName}
 npm install --no-save @typescript/server-replay
@@ -492,6 +511,14 @@ To run the repro:
 # \`npx tsreplay --help\` to learn about helpful switches for debugging, logging, etc.
 npx tsreplay ./${summary.repo.name} ./${summary.replayScriptName} <PATH_TO_tsserver.js>
 \`\`\``;
+
+        text += `
+${proseSteps}
+
+${bashScript}
+</details>
+`;
+
     }
 
     return text;

--- a/src/main.ts
+++ b/src/main.ts
@@ -455,6 +455,8 @@ ${summary.replayScript}
 <h4>Repro steps</h4>
 
 \`\`\`bash
+#!/bin/bash
+
 `;
         // No url means is user test repo
         if (!summary.repo.url) {
@@ -491,7 +493,10 @@ To run the repro:
 \`\`\`bash
 # \`npx tsreplay --help\` to learn about helpful switches for debugging, logging, etc.
 npx tsreplay ./${summary.repo.name} ./${summary.replayScriptName} <PATH_TO_tsserver.js>
-\`\`\``;
+\`\`\`
+
+</details>
+`;
     }
 
     return text;

--- a/src/postGithubIssue.ts
+++ b/src/postGithubIssue.ts
@@ -74,8 +74,8 @@ ${Object.keys(statusCounts).sort().map(status => `| ${status} | ${statusCounts[s
 const resultPaths = pu.glob(resultDirPath, `**/*.${resultFileNameSuffix}`).sort((a, b) => path.basename(a).localeCompare(path.basename(b)));
 const outputs = resultPaths.map(p =>
     fs.readFileSync(p, { encoding: "utf-8" })
-        .replace(new RegExp(artifactFolderUrlPlaceholder, "g"), artifactsUri)
-        .replace(new RegExp(getArtifactsApiUrlPlaceholder, "g"), getArtifactsApi));
+        .replaceAll(artifactFolderUrlPlaceholder, artifactsUri)
+        .replaceAll(getArtifactsApiUrlPlaceholder, getArtifactsApi));
 
 for (let i = 0; i < outputs.length; i++) {
     const resultPath = resultPaths[i];

--- a/src/postGithubIssue.ts
+++ b/src/postGithubIssue.ts
@@ -1,17 +1,17 @@
 import fs = require("fs");
 import path = require("path");
-import { artifactFolderUrlPlaceholder, Metadata, metadataFileName, RepoStatus, resultFileNameSuffix, StatusCounts, TsEntrypoint } from "./main";
+import { artifactFolderUrlPlaceholder, getArtifactsApiUrlPlaceholder, Metadata, metadataFileName, RepoStatus, resultFileNameSuffix, StatusCounts, TsEntrypoint } from "./main";
 import git = require("./utils/gitUtils");
 import pu = require("./utils/packageUtils");
 
 const { argv } = process;
 
-if (argv.length !== 10) {
-    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <ts_entrypoint> <language> <repo_count> <repo_start_index> <result_dir_path> <log_uri> <artifacts_uri> <post_result>`);
+if (argv.length !== 11) {
+    console.error(`Usage: ${path.basename(argv[0])} ${path.basename(argv[1])} <ts_entrypoint> <language> <repo_count> <repo_start_index> <result_dir_path> <log_uri> <artifacts_uri> <post_result> <get_artifacts_api>`);
     process.exit(-1);
 }
 
-const [, , ep, language, repoCount, repoStartIndex, resultDirPath, logUri, artifactsUri, post] = argv;
+const [, , ep, language, repoCount, repoStartIndex, resultDirPath, logUri, artifactsUri, post, getArtifactsApi] = argv;
 const postResult = post.toLowerCase() === "true";
 const entrypoint = ep as TsEntrypoint;
 
@@ -72,7 +72,10 @@ ${Object.keys(statusCounts).sort().map(status => `| ${status} | ${statusCounts[s
 `;
 
 const resultPaths = pu.glob(resultDirPath, `**/*.${resultFileNameSuffix}`).sort((a, b) => path.basename(a).localeCompare(path.basename(b)));
-const outputs = resultPaths.map(p => fs.readFileSync(p, { encoding: "utf-8" }).replace(new RegExp(artifactFolderUrlPlaceholder, "g"), artifactsUri));
+const outputs = resultPaths.map(p =>
+    fs.readFileSync(p, { encoding: "utf-8" })
+        .replace(new RegExp(artifactFolderUrlPlaceholder, "g"), artifactsUri)
+        .replace(new RegExp(getArtifactsApiUrlPlaceholder, "g"), getArtifactsApi));
 
 for (let i = 0; i < outputs.length; i++) {
     const resultPath = resultPaths[i];

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -41,6 +41,22 @@ Raw error text: <code>RepoResults123/MockRepoOwner.MockRepoName.rawError.txt</co
 \`\`\`
 
 <h4>Repro steps</h4>
+<ol>
+<li><code>git clone https://github.com/MockRepoOwner/MockRepoName --recurse-submodules</code></li>
+<li>In dir <code>MockRepoName</code>, run <code>git reset --hard 57b462387e88aa7e363af0daf867a5dc1e83a935</code></li>
+<li><details><summary>Install packages (exact steps are below, but it might be easier to follow the repo readme)</summary><ol>
+  <li>In dir <code>dirA</code>, run <code>npm install --prefer-offline --no-audit --no-progress --legacy-peer-deps --ignore-scripts -q</code></li>
+  <li>In dir <code>dirB/dirC</code>, run <code>npm install --prefer-offline --no-audit --no-progress --legacy-peer-deps --ignore-scripts -q</code></li>
+  <li>In dir <code>dirD/dirE/dirF</code>, run <code>npm install --prefer-offline --no-audit --no-progress --legacy-peer-deps --ignore-scripts -q</code></li>
+</ol></details>
+<li>Back in the initial folder, download <code>RepoResults123/MockRepoOwner.MockRepoName.replay.txt</code> from the <a href="PLACEHOLDER_ARTIFACT_FOLDER">artifact folder</a></li>
+<li><code>npm install --no-save @typescript/server-replay</code></li>
+<li><code>npx tsreplay ./MockRepoName ./MockRepoOwner.MockRepoName.replay.txt path/to/tsserver.js</code></li>
+<li><code>npx tsreplay --help</code> to learn about helpful switches for debugging, logging, etc</li>
+</ol>
+
+
+<h5>Bash script</h5>
 
 \`\`\`bash
 git clone https://github.com/MockRepoOwner/MockRepoName --recurse-submodules
@@ -59,7 +75,9 @@ To run the repro:
 \`\`\`bash
 # \`npx tsreplay --help\` to learn about helpful switches for debugging, logging, etc.
 npx tsreplay ./MockRepoName ./MockRepoOwner.MockRepoName.replay.txt <PATH_TO_tsserver.js>
-\`\`\`",
+\`\`\`
+</details>
+",
       {
         "encoding": "utf-8",
       },

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -15,7 +15,7 @@ Maybe a Debug fail.
     at e (/mnt/vss/_work/1/s/typescript-1.1.1/lib/typescript.js:5:5)",
     ],
     [
-      "<BASE_PATH>/artifacts/718e48b799650d4b66e5d80ad6bac7b9.results.txt",
+      "<BASE_PATH>/RepoResults123/718e48b799650d4b66e5d80ad6bac7b9.results.txt",
       "<h2>Maybe a Debug fail.</h2>
 
 \`\`\`
@@ -30,7 +30,7 @@ Req #123 - cursedCommand
 <h4>Affected repos</h4>
 <details>
 <summary><a href="https://github.com/MockRepoOwner/MockRepoName">MockRepoOwner/MockRepoName</a></summary>
-Raw error text: <code>artifacts/MockRepoOwner.MockRepoName.rawError.txt</code> in the <a href="PLACEHOLDER_ARTIFACT_FOLDER">artifact folder</a>
+Raw error text: <code>RepoResults123/MockRepoOwner.MockRepoName.rawError.txt</code> in the <a href="PLACEHOLDER_ARTIFACT_FOLDER">artifact folder</a>
 <h4>Last few requests</h4>
 
 \`\`\`json
@@ -41,27 +41,31 @@ Raw error text: <code>artifacts/MockRepoOwner.MockRepoName.rawError.txt</code> i
 \`\`\`
 
 <h4>Repro steps</h4>
-<ol>
-<li><code>git clone https://github.com/MockRepoOwner/MockRepoName --recurse-submodules</code></li>
-<li>In dir <code>MockRepoName</code>, run <code>git reset --hard 57b462387e88aa7e363af0daf867a5dc1e83a935</code></li>
-<li><details><summary>Install packages (exact steps are below, but it might be easier to follow the repo readme)</summary><ol>
-  <li>In dir <code>dirA</code>, run <code>npm --prefer-offline --no-audit --no-progress --legacy-peer-deps --ignore-scripts -q</code></li>
-  <li>In dir <code>dirB/dirC</code>, run <code>npm --prefer-offline --no-audit --no-progress --legacy-peer-deps --ignore-scripts -q</code></li>
-  <li>In dir <code>dirD/dirE/dirF</code>, run <code>npm --prefer-offline --no-audit --no-progress --legacy-peer-deps --ignore-scripts -q</code></li>
-</ol></details>
-<li>Back in the initial folder, download <code>artifacts/MockRepoOwner.MockRepoName.replay.txt</code> from the <a href="PLACEHOLDER_ARTIFACT_FOLDER">artifact folder</a></li>
-<li><code>npm install --no-save @typescript/server-replay</code></li>
-<li><code>npx tsreplay ./MockRepoName ./MockRepoOwner.MockRepoName.replay.txt path/to/tsserver.js</code></li>
-<li><code>npx tsreplay --help</code> to learn about helpful switches for debugging, logging, etc</li>
-</ol>
-</details>
-",
+
+\`\`\`bash
+git clone https://github.com/MockRepoOwner/MockRepoName --recurse-submodules
+git -C "./MockRepoName" reset --hard 57b462387e88aa7e363af0daf867a5dc1e83a935
+# Install packages (exact steps are below, but it might be easier to follow the repo readme)
+npm --prefix "./dirA" install --prefer-offline --no-audit --no-progress --legacy-peer-deps --ignore-scripts -q
+npm --prefix "./dirB/dirC" install --prefer-offline --no-audit --no-progress --legacy-peer-deps --ignore-scripts -q
+npm --prefix "./dirD/dirE/dirF" install --prefer-offline --no-audit --no-progress --legacy-peer-deps --ignore-scripts -q
+downloadUrl=$(curl -s "PLACEHOLDER_GETARTIFACTS_API?artifactName=RepoResults123&api-version=7.0" | jq -r ".resource.downloadUrl")
+wget -O RepoResults123.zip "$downloadUrl"
+unzip -p RepoResults123.zip RepoResults123/MockRepoOwner.MockRepoName.replay.txt > MockRepoOwner.MockRepoName.replay.txt
+npm install --no-save @typescript/server-replay
+\`\`\`
+
+To run the repro:
+\`\`\`bash
+# \`npx tsreplay --help\` to learn about helpful switches for debugging, logging, etc.
+npx tsreplay ./MockRepoName ./MockRepoOwner.MockRepoName.replay.txt <PATH_TO_tsserver.js>
+\`\`\`",
       {
         "encoding": "utf-8",
       },
     ],
     [
-      "<BASE_PATH>/artifacts/metadata.json",
+      "<BASE_PATH>/RepoResults123/metadata.json",
       "{"newTsResolvedVersion":"1.1.1","oldTsResolvedVersion":"0.0.0","statusCounts":{"Detected interesting changes":1}}",
       {
         "encoding": "utf-8",

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -43,6 +43,8 @@ Raw error text: <code>RepoResults123/MockRepoOwner.MockRepoName.rawError.txt</co
 <h4>Repro steps</h4>
 
 \`\`\`bash
+#!/bin/bash
+
 git clone https://github.com/MockRepoOwner/MockRepoName --recurse-submodules
 git -C "./MockRepoName" reset --hard 57b462387e88aa7e363af0daf867a5dc1e83a935
 # Install packages (exact steps are below, but it might be easier to follow the repo readme)
@@ -59,7 +61,10 @@ To run the repro:
 \`\`\`bash
 # \`npx tsreplay --help\` to learn about helpful switches for debugging, logging, etc.
 npx tsreplay ./MockRepoName ./MockRepoOwner.MockRepoName.replay.txt <PATH_TO_tsserver.js>
-\`\`\`",
+\`\`\`
+
+</details>
+",
       {
         "encoding": "utf-8",
       },

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -41,22 +41,6 @@ Raw error text: <code>RepoResults123/MockRepoOwner.MockRepoName.rawError.txt</co
 \`\`\`
 
 <h4>Repro steps</h4>
-<ol>
-<li><code>git clone https://github.com/MockRepoOwner/MockRepoName --recurse-submodules</code></li>
-<li>In dir <code>MockRepoName</code>, run <code>git reset --hard 57b462387e88aa7e363af0daf867a5dc1e83a935</code></li>
-<li><details><summary>Install packages (exact steps are below, but it might be easier to follow the repo readme)</summary><ol>
-  <li>In dir <code>dirA</code>, run <code>npm install --prefer-offline --no-audit --no-progress --legacy-peer-deps --ignore-scripts -q</code></li>
-  <li>In dir <code>dirB/dirC</code>, run <code>npm install --prefer-offline --no-audit --no-progress --legacy-peer-deps --ignore-scripts -q</code></li>
-  <li>In dir <code>dirD/dirE/dirF</code>, run <code>npm install --prefer-offline --no-audit --no-progress --legacy-peer-deps --ignore-scripts -q</code></li>
-</ol></details>
-<li>Back in the initial folder, download <code>RepoResults123/MockRepoOwner.MockRepoName.replay.txt</code> from the <a href="PLACEHOLDER_ARTIFACT_FOLDER">artifact folder</a></li>
-<li><code>npm install --no-save @typescript/server-replay</code></li>
-<li><code>npx tsreplay ./MockRepoName ./MockRepoOwner.MockRepoName.replay.txt path/to/tsserver.js</code></li>
-<li><code>npx tsreplay --help</code> to learn about helpful switches for debugging, logging, etc</li>
-</ol>
-
-
-<h5>Bash script</h5>
 
 \`\`\`bash
 git clone https://github.com/MockRepoOwner/MockRepoName --recurse-submodules
@@ -75,9 +59,7 @@ To run the repro:
 \`\`\`bash
 # \`npx tsreplay --help\` to learn about helpful switches for debugging, logging, etc.
 npx tsreplay ./MockRepoName ./MockRepoOwner.MockRepoName.replay.txt <PATH_TO_tsserver.js>
-\`\`\`
-</details>
-",
+\`\`\`",
       {
         "encoding": "utf-8",
       },

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -76,6 +76,7 @@ jest.mock('../src/utils/installPackages', () => {
     const npmCommand = {
         tool: 'npm',
         arguments: [
+            'install',
             '--prefer-offline',
             '--no-audit',
             '--no-progress',
@@ -156,7 +157,7 @@ describe("main", () => {
             workerNumber: 1,
             oldTsNpmVersion: 'latest',
             newTsNpmVersion: 'next',
-            resultDirName: './artifacts',
+            resultDirName: 'RepoResults123',
             prngSeed: 'testSeed',
         });
 


### PR DESCRIPTION
Fixes #88 

Removes the prose repro steps for a bash script instead. 

It's fairly easy to add other shells but I'm starting with Bash as the project already depends on Linux. Based on feedback I'll decide if it's worth adding them.
 
Note that when running the tsserver user-tests, there's no command for downloading the repository as I was not able to get the information easily. It's still added as comment.