### PR TITLE
Try and kill processes using mounted tmpfs

### DIFF
--- a/src/utils/overlayFS.ts
+++ b/src/utils/overlayFS.ts
@@ -110,12 +110,20 @@ async function tryUnmount(p: string) {
                 await execAsync(processCwd, `sudo umount -R ${p}`);
             } catch {
                 // Kill processes using the mount.
-                await execAsync(processCwd, `sudo fuser -vkm ${p}`);
+                try {
+                    await execAsync(processCwd, `sudo fuser -vkm ${p}`);
+                } catch {
+                    // This command will exit with a non-zero exit code on no handles; ignore.
+                }
             }
         }, 3, 1000)
     } catch {
         // Print out the remaining processes for debugging.
-        await execAsync(processCwd, `sudo fuser -vm ${p}`);
+        try {
+            await execAsync(processCwd, `sudo fuser -vm ${p}`);
+        } catch {
+            // This command will exit with a non-zero exit code on no handles; ignore.
+        }
     }
 }
 


### PR DESCRIPTION
As an example: https://typescript.visualstudio.com/TypeScript/_build/results?buildId=161742&view=logs&j=f9b5d541-fe53-5859-f5ff-84cb11addb3b&t=4a75e90a-a5e8-5f79-11df-d064d463e50a

```
/mnt/ts_downloads/base/nest> /opt/hostedtoolcache/node/20.12.2/x64/bin/node /mnt/vss/_work/1/s/dist/utils/exerciseServer.js /mnt/ts_downloads/base/nest /mnt/ts_downloads/base/nestjs.nest.replay.txt /mnt/vss/_work/1/s/typescript-58528/built/local/tsserver.js false
Exited with code 1
ExitCode: 1
Signal: null
stdout:
>>>

<<<
stderr:
>>>
node:internal/process/promises:289
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[Error: ENOSPC: no space left on device, write] {
  errno: -28,
  code: 'ENOSPC',
  syscall: 'write'
}

Node.js v20.12.2

<<<
```

```
Done https://github.com/nestjs/nest
Repo https://github.com/nestjs/nest had status "Unknown failure"
/mnt/vss/_work/1/s> sudo umount -R /mnt/ts_downloads
umount: /mnt/ts_downloads: target is busy.

/mnt/vss/_work/1/s> sudo lsof /mnt/ts_downloads
COMMAND   PID      USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
node    12076 cloudtest  cwd    DIR   0,44      740    3 /mnt/ts_downloads/base/nest

/mnt/vss/_work/1/s> sudo rm -rf /mnt/ts_downloads
rm: cannot remove '/mnt/ts_downloads': Device or resource busy

/mnt/vss/_work/1/s> sudo rm -rf /mnt/ts_downloads
rm: cannot remove '/mnt/ts_downloads': Device or resource busy

/mnt/vss/_work/1/s> sudo rm -rf /mnt/ts_downloads
rm: cannot remove '/mnt/ts_downloads': Device or resource busy

Unhandled exception:
```

The tmpfs was filled up, which the tsserver tests are actually okay with. But then there's some random process open that is preventing the unmount, so we fail.

We can just kill processes that are using the mount; it can only be test processes and freeing up the mount will give the memory back.