### PR TITLE
Fix command directory, removed investigation status for tsserver

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -481,7 +481,7 @@ ${summary.replayScript}
                     ? "--cwd"
                     : "--dir"; // pnpm
 
-            text += `${command.tool} ${workingDirFlag} "${command.directory}" ${command.arguments.join(" ")}\n`;
+            text += `${command.tool} ${workingDirFlag} "./${command.prettyDirectory}" ${command.arguments.join(" ")}\n`;
         }
 
         text += `downloadUrl=$(curl -s "${getArtifactsApiUrlPlaceholder}?artifactName=${summary.resultDirName}&api-version=7.0" | jq -r ".resource.downloadUrl")

--- a/src/postGithubIssue.ts
+++ b/src/postGithubIssue.ts
@@ -77,26 +77,28 @@ const outputs = resultPaths.map(p =>
         .replaceAll(artifactFolderUrlPlaceholder, artifactsUri)
         .replaceAll(getArtifactsApiUrlPlaceholder, getArtifactsApi));
 
-for (let i = 0; i < outputs.length; i++) {
-    const resultPath = resultPaths[i];
-    const output = outputs[i];
 
-    const fileName = path.basename(resultPath);
-    const repoString = fileName.substring(0, fileName.length - resultFileNameSuffix.length - 1);
-    const repoName = repoString.replace(".", "/"); // The owner *probably* doesn't have a dot in it
+// tsserver groups results by error, causing the summary to not make sense. Remove the list for now.
+// See issue: https://github.com/microsoft/typescript-error-deltas/issues/114
+if (entrypoint !== "tsserver") {
+    // Prints the investigation status list.
+    for (let i = 0; i < outputs.length; i++) {
+        const resultPath = resultPaths[i];
+        const output = outputs[i];
 
-    let errorCount = 0;
-    if (entrypoint === "tsserver") {
-        errorCount = 1;
-    }
-    else {
+        const fileName = path.basename(resultPath);
+        const repoString = fileName.substring(0, fileName.length - resultFileNameSuffix.length - 1);
+        const repoName = repoString.replace(".", "/"); // The owner *probably* doesn't have a dot in it
+
+        let errorCount = 0;
+
         const re = /^\W*error TS\d+/gm;
         while (re.exec(output)) {
             errorCount++;
         }
-    }
 
-    header += `|${repoName}|${errorCount}| |\n`;
+        header += `|${repoName}|${errorCount}| |\n`;
+    }
 }
 
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -92,17 +92,17 @@ jest.mock('../src/utils/installPackages', () => {
             return [
                 {
                     ...npmCommand,
-                    directory: './dirA',
+                    directory: '/mnt/repos/dirA',
                     prettyDirectory: 'dirA',
                 },
                 {
                     ...npmCommand,
-                    directory: './dirB/dirC',
+                    directory: '/mnt/repos/dirB/dirC',
                     prettyDirectory: 'dirB/dirC',
                 },
                 {
                     ...npmCommand,
-                    directory: './dirD/dirE/dirF',
+                    directory: '/mnt/repos/dirD/dirE/dirF',
                     prettyDirectory: 'dirD/dirE/dirF',
                 }
             ]


### PR DESCRIPTION
Fixes the package manager commands showing the server path instead of a relative path. Example: 
```
yarn --cwd "/mnt/ts_downloads/base/styled-components" install --no-immutable --mode=skip-build
vs
yarn --cwd "./styled-components" install --no-immutable --mode=skip-build
```

Also removes from the ServerErrors the investigation summary as currently don't add any valuable information.

Here's a test run with the fixes: https://github.com/microsoft/TypeScript/issues/58769