### PR TITLE
Truncate issue comments

### DIFF
--- a/src/utils/gitUtils.ts
+++ b/src/utils/gitUtils.ts
@@ -137,8 +137,16 @@ export async function createIssue(postResult: boolean, title: string, bodyChunks
     const issueNumber = created.data.number;
     console.log(`Created issue #${issueNumber}: ${created.data.html_url}`);
 
+    const maxCommentLength = 65535;
+    const tooLongFooter = `\n\nThis comment was too long to display in full; see the build artifact for the full details.`;
+
     for (const comment of additionalComments) {
-        await kit.issues.createComment({ issue_number: issueNumber, ...comment });
+        let body = comment.body;
+        if (body.length > maxCommentLength) {
+            body = body.slice(0, maxCommentLength - tooLongFooter.length) + tooLongFooter;
+        }
+
+        await kit.issues.createComment({ issue_number: issueNumber, ...comment, body });
     }
 
     if (!sawNewErrors) {


### PR DESCRIPTION
https://typescript.visualstudio.com/TypeScript/_build/results?buildId=162915&view=logs&j=15ac8a4d-b341-5815-5352-14d7ae9c5a86&t=b4a5e2cd-8727-5d20-e3d3-86822d3c46a6 failed because it tried to send a comment that was too long.

Truncate these with a message instead of failing.

We could chunk them like the other thing, maybe.