### PR TITLE
Properly escape backticks in error messages

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import mdEscape = require("markdown-escape");
 import randomSeed = require("random-seed");
 import { getErrorMessageFromStack, getHash, getHashForStack } from "./utils/hashStackTrace";
 import { createCopyingOverlayFS, createTempOverlayFS, OverlayBaseFS } from "./utils/overlayFS";
+import { asMarkdownInlineCode } from "./utils/markdownUtils";
 
 interface Params {
     /**
@@ -434,7 +435,7 @@ ${summary.replayScript}
 `;
         // No url means is user test repo
         if (!summary.repo.url) {
-            text += `# Manually download user test \`${summary.repo.name}\`\n`;
+            text += `# Manually download user test ${asMarkdownInlineCode(summary.repo.name)}\n`;
         }
         else {
             text += `git clone ${summary.repo.url} --recurse-submodules\n`;
@@ -512,7 +513,7 @@ ${summary.replayScript}
 `;
         // No url means is user test repo
         if (!summary.repo.url) {
-            text += `# Manually download user test \`${summary.repo.name}\`\n`;
+            text += `# Manually download user test ${asMarkdownInlineCode(summary.repo.name)}\n`;
         }
         else {
             text += `git clone ${summary.repo.url} --recurse-submodules\n`;
@@ -721,7 +722,7 @@ export async function getTscRepoResult(
             summary += `### ${makeMarkdownLink(projectUrl)}\n`;
 
             for (const errorMessage of newlyReportedErrorMessages) {
-                summary += ` - ${buildWithNewWhenOldFails ? "[NEW] " : ""}\`${errorMessage}\`\n`;
+                summary += ` - ${buildWithNewWhenOldFails ? "[NEW] " : ""}${asMarkdownInlineCode(errorMessage)}\n`;
 
                 for (const error of newlyReportedErrorMessageMap.get(errorMessage)!) {
                     summary += `   - ${error.fileUrl ? makeMarkdownLink(error.fileUrl) : "Project Scope"}${isComposite ? ` in ${makeMarkdownLink(error.projectUrl)}` : ``}\n`;
@@ -729,7 +730,7 @@ export async function getTscRepoResult(
             }
 
             for (const errorMessage of newlyUnreportedErrorMessages) {
-                summary += ` - ${buildWithNewWhenOldFails ? "[MISSING] " : ""}\`${errorMessage}\`\n`;
+                summary += ` - ${buildWithNewWhenOldFails ? "[MISSING] " : ""}${asMarkdownInlineCode(errorMessage)}\n`;
 
                 for (const error of newlyUnreportedErrorMessageMap.get(errorMessage)!) {
                     summary += `   - ${error.fileUrl ? makeMarkdownLink(error.fileUrl) : "Project Scope"}${isComposite ? ` in ${makeMarkdownLink(error.projectUrl)}` : ``}\n`;

--- a/src/postGithubComments.ts
+++ b/src/postGithubComments.ts
@@ -3,6 +3,7 @@ import path = require("path");
 import { artifactFolderUrlPlaceholder, getArtifactsApiUrlPlaceholder, Metadata, metadataFileName, RepoStatus, resultFileNameSuffix } from "./main";
 import git = require("./utils/gitUtils");
 import pu = require("./utils/packageUtils");
+import { asMarkdownInlineCode } from "./utils/markdownUtils";
 
 const { argv } = process;
 
@@ -76,7 +77,7 @@ const outputs = resultPaths.map(p =>
         .replaceAll(getArtifactsApiUrlPlaceholder, getArtifactsApi));
 
 const suiteDescription = isTopReposRun ? `top ${repoCount} repos` : "user tests";
-let header = `@${userToTag} Here are the results of running the ${suiteDescription} with ${entrypoint} comparing \`${oldTscResolvedVersion}\` and \`${newTscResolvedVersion}\`:
+let header = `@${userToTag} Here are the results of running the ${suiteDescription} with ${entrypoint} comparing ${asMarkdownInlineCode(oldTscResolvedVersion ?? "old")} and ${asMarkdownInlineCode(newTscResolvedVersion ?? "new")}:
 
 ${summary.join("\n")}`;
 

--- a/src/utils/markdownUtils.ts
+++ b/src/utils/markdownUtils.ts
@@ -1,0 +1,9 @@
+export function asMarkdownInlineCode(s: string) {
+    let backticks = "`";
+    let space = "";
+    while (s.includes(backticks)) {
+        backticks += "`";
+        space = " "
+    }
+    return `${backticks}${space}${s}${space}${backticks}`;
+}


### PR DESCRIPTION
Fixes stuff like:

![image](https://github.com/user-attachments/assets/ece2bf4a-d10e-4393-8e97-815610755e52)

