### PR TITLE
Updated server-replay to version 0.2.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@octokit/rest": "^20.0.2",
                 "@typescript/github-link": "^0.2.2",
                 "@typescript/server-harness": "^0.3.5",
-                "@typescript/server-replay": "^0.2.12",
+                "@typescript/server-replay": "^0.2.13",
                 "glob": "^10.3.10",
                 "js-yaml": "^4.1.0",
                 "json5": "^2.2.3",
@@ -1477,9 +1477,9 @@
             "integrity": "sha512-YT9oe27zm7HdGXYad5SZrdJzVe9eavG3F6YplsWvAraowGtuDeY7FHPVuQPtQj6GxG097Us4JDkA8n5I4iQovQ=="
         },
         "node_modules/@typescript/server-replay": {
-            "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/@typescript/server-replay/-/server-replay-0.2.12.tgz",
-            "integrity": "sha512-zpyROWQNmbcJ1F6hSf3f1YGxuyUUsgJv4vz7MrJYwkM6bJ7V7zQjv4GjAFzDKggLVyLU9/dUXtD2xl6FQ3SKZQ==",
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/@typescript/server-replay/-/server-replay-0.2.13.tgz",
+            "integrity": "sha512-+BTWfJtCNYMmFCzz0x2OVPJYJlhmRWc/CKuF0kwm3yYJtKTzqRuPn+FEgexEmADuGbv/HKF8stZkJ2KUKje1Wg==",
             "dependencies": {
                 "@typescript/server-harness": "^0.3.4",
                 "yargs": "^16.2.0"
@@ -5809,9 +5809,9 @@
             "integrity": "sha512-YT9oe27zm7HdGXYad5SZrdJzVe9eavG3F6YplsWvAraowGtuDeY7FHPVuQPtQj6GxG097Us4JDkA8n5I4iQovQ=="
         },
         "@typescript/server-replay": {
-            "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/@typescript/server-replay/-/server-replay-0.2.12.tgz",
-            "integrity": "sha512-zpyROWQNmbcJ1F6hSf3f1YGxuyUUsgJv4vz7MrJYwkM6bJ7V7zQjv4GjAFzDKggLVyLU9/dUXtD2xl6FQ3SKZQ==",
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/@typescript/server-replay/-/server-replay-0.2.13.tgz",
+            "integrity": "sha512-+BTWfJtCNYMmFCzz0x2OVPJYJlhmRWc/CKuF0kwm3yYJtKTzqRuPn+FEgexEmADuGbv/HKF8stZkJ2KUKje1Wg==",
             "requires": {
                 "@typescript/server-harness": "^0.3.4",
                 "yargs": "^16.2.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "@octokit/rest": "^20.0.2",
         "@typescript/github-link": "^0.2.2",
         "@typescript/server-harness": "^0.3.5",
-        "@typescript/server-replay": "^0.2.12",
+        "@typescript/server-replay": "^0.2.13",
         "glob": "^10.3.10",
         "js-yaml": "^4.1.0",
         "json5": "^2.2.3",


### PR DESCRIPTION
Updated npm package server-replay to include the latest change about increasing the stack size. See: https://github.com/microsoft/typescript-server-replay/pull/10