### PR TITLE
Increase stack size

### DIFF
--- a/src/utils/exerciseServer.ts
+++ b/src/utils/exerciseServer.ts
@@ -75,6 +75,7 @@ async function exerciseServerWorker(testDir: string, tsserverPath: string, repla
         serverArgs,
     }) + "\n");
 
+    // Keep in sync with typescrit-server-replay repo: https://github.com/microsoft/typescript-server-replay/blob/0cf42b98c3592805901c9de025b59315b6fd2a80/replay.js#L234
     const server = sh.launchServer(
         tsserverPath,
         serverArgs,

--- a/src/utils/exerciseServer.ts
+++ b/src/utils/exerciseServer.ts
@@ -81,6 +81,7 @@ async function exerciseServerWorker(testDir: string, tsserverPath: string, repla
         [
             "--max-old-space-size=4096",
             "--expose-gc",
+            "--stack-size=2048",
         ]);
 
     // You can only wait for kill if the process being killed is the current process's


### PR DESCRIPTION
Fixed the Maximum Call Stack messages reported by the bot.

This is a follow up for PR: https://github.com/microsoft/typescript-server-replay/pull/10, that misses increasing the size on this repo.