### PR TITLE
Revert "Revert "Switch back to mariner-2.0 again""

### DIFF
--- a/azure-pipelines-gitTests-tsserver-js.yml
+++ b/azure-pipelines-gitTests-tsserver-js.yml
@@ -12,7 +12,7 @@ trigger: none
 pool:
   name: TypeScript-1ES-Large
   demands:
-    - ImageOverride -equals ubuntu-22.04
+    - ImageOverride -equals mariner-2.0
 
 extends:
   template: azure-pipelines-gitTests-template.yml

--- a/azure-pipelines-gitTests-tsserver-ts.yml
+++ b/azure-pipelines-gitTests-tsserver-ts.yml
@@ -12,7 +12,7 @@ trigger: none
 pool:
   name: TypeScript-1ES-Large
   demands:
-    - ImageOverride -equals ubuntu-22.04
+    - ImageOverride -equals mariner-2.0
 
 extends:
   template: azure-pipelines-gitTests-template.yml

--- a/azure-pipelines-gitTests.yml
+++ b/azure-pipelines-gitTests.yml
@@ -66,7 +66,7 @@ trigger: none
 pool:
   name: TypeScript-1ES-Large
   demands:
-    - ImageOverride -equals ubuntu-22.04
+    - ImageOverride -equals mariner-2.0
 
 variables:
   Codeql.Enabled: false

--- a/azure-pipelines-userTests.yml
+++ b/azure-pipelines-userTests.yml
@@ -63,7 +63,7 @@ trigger: none
 pool:
   name: TypeScript-1ES-Large
   demands:
-    - ImageOverride -equals ubuntu-22.04
+    - ImageOverride -equals mariner-2.0
 
 variables:
   Codeql.Enabled: false


### PR DESCRIPTION
Reverts microsoft/typescript-error-deltas#182

Actually switches back to mariner-2.0; the same out of space errors are happening on ubuntu. The runner doesn't even run on `/` so it doesn't even matter.