### PR TITLE
Fix vscode

### DIFF
--- a/userTests/vscode/build.sh
+++ b/userTests/vscode/build.sh
@@ -1,22 +1,15 @@
-# TODO: building vs code relies on python 3 as well
-# although it might be part of node-gyp's postinstall script and could be skipped safely
-apt-get update
-apt-get install libsecret-1-dev libx11-dev libxkbfile-dev -y
-npm i -g yarn --force
 rm -rf vscode
 git clone --depth 1 https://github.com/microsoft/vscode.git vscode
 START=$(pwd)
 cd $TS
-rm ~/.config/yarn/link/typescript
-yarn link
+npm link
 
 cd $START/vscode/build
-yarn link typescript
+npm link typescript
 cd $START/vscode/extensions
-yarn add rimraf
-yarn link typescript
+npm add rimraf
+npm link typescript
 cd $START/vscode
-yarn link typescript
-yarn
-yarn compile
-
+npm link typescript
+npm install
+npm run compile


### PR DESCRIPTION
vscode switched to npm, so this was broken, and then I switched our image to mariner, so it was double broken.

I've installed the required libs on the builder image, so just fix npm now and remove the apt-get.