### PR TITLE
Fix build scripts, permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,12 @@ jobs:
 
     - name: Test
       run: npm test
+
+    - name: Check scripts are executable
+      run: |
+        for i in userTests/*/*.sh; do
+          if ! [[ -x "$i" ]]; then
+            echo "File $i is not executable"
+            exit 1
+          fi
+        done

--- a/userTests/angular/build.sh
+++ b/userTests/angular/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 npm i -g yarn --force
 rm -rf angular
 git clone --depth 1 https://github.com/angular/angular angular

--- a/userTests/arktype/build.sh
+++ b/userTests/arktype/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -x
 
 npm i -g pnpm

--- a/userTests/azure-sdk/build.sh
+++ b/userTests/azure-sdk/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -x
 npm install -g @microsoft/rush
 rm -rf azure-sdk

--- a/userTests/chrome-devtools-frontend-next/build.sh
+++ b/userTests/chrome-devtools-frontend-next/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 rm -rf depot_tools
 git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git depot_tools
 PATH=depot_tools:$PATH

--- a/userTests/office-ui-fabric/build.sh
+++ b/userTests/office-ui-fabric/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 npm i -g yarn
 rm -rf office-ui-fabric
 CI=true

--- a/userTests/prettier/build.sh
+++ b/userTests/prettier/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 npm i -g yarn
 rm -rf prettier
 git clone --depth 1 https://github.com/prettier/prettier.git prettier

--- a/userTests/pyright/build.sh
+++ b/userTests/pyright/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 rm -rf pyright
 git clone --depth 1 https://github.com/microsoft/pyright.git pyright
 START=$(pwd)

--- a/userTests/rxjs-src/build.sh
+++ b/userTests/rxjs-src/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 rm -rf rxjs
 git clone --depth 1 https://github.com/ReactiveX/rxjs rxjs
 START=$(pwd)

--- a/userTests/typescript-eslint/build.sh
+++ b/userTests/typescript-eslint/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -x
 
 npm i -g yarn

--- a/userTests/vscode/build.sh
+++ b/userTests/vscode/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 rm -rf vscode
 git clone --depth 1 https://github.com/microsoft/vscode.git vscode
 START=$(pwd)

--- a/userTests/vue-next/build.sh
+++ b/userTests/vue-next/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 npm install -g pnpm
 rm -rf vue-next
 git clone --depth 1 https://github.com/vuejs/core


### PR DESCRIPTION
The new arktype build.sh was not `chmod +x`'d. Check that in CI.

While here, add the shebangs that should have been there but were only working due to weird system defaults for executing files.