### PR TITLE
unblocks manually triggered tsgo server tests

### DIFF
--- a/azure-pipelines-userTests.yml
+++ b/azure-pipelines-userTests.yml
@@ -68,6 +68,10 @@ pool:
 variables:
   Codeql.Enabled: false
   skipComponentGovernanceDetection: true
+  ${{ if and(eq(parameters.ENTRYPOINT, 'tsserver'), contains(parameters.OLD_TS_REPO_URL, 'typescript-go')) }}:
+    effectiveEntrypoint: lsp
+  ${{ else }}:
+    effectiveEntrypoint: ${{ parameters.ENTRYPOINT }}
 
 jobs:
 - job: ListRepos
@@ -135,7 +139,7 @@ jobs:
       corepack enable
       corepack enable npm
       mkdir 'RepoResults$(System.JobPositionInPhase)'
-      node dist/checkUserTestRepos ${{ parameters.ENTRYPOINT }} ${{ parameters.OLD_TS_REPO_URL }} ${{ parameters.OLD_HEAD_REF }} ${{ parameters.SOURCE_ISSUE }} ${{ parameters.TOP_REPOS }} '$(Pipeline.Workspace)/RepoList/repos.json' $(System.TotalJobsInPhase) $(System.JobPositionInPhase) 'RepoResults$(System.JobPositionInPhase)' ${{ parameters.DIAGNOSTIC_OUTPUT }} ${{ parameters.PRNG_SEED }}
+      node dist/checkUserTestRepos ${{ variables.effectiveEntrypoint }} ${{ parameters.OLD_TS_REPO_URL }} ${{ parameters.OLD_HEAD_REF }} ${{ parameters.SOURCE_ISSUE }} ${{ parameters.TOP_REPOS }} '$(Pipeline.Workspace)/RepoList/repos.json' $(System.TotalJobsInPhase) $(System.JobPositionInPhase) 'RepoResults$(System.JobPositionInPhase)' ${{ parameters.DIAGNOSTIC_OUTPUT }} ${{ parameters.PRNG_SEED }}
     displayName: 'Run user tests'
   - publish: 'RepoResults$(System.JobPositionInPhase)'
     artifact: 'RepoResults$(System.JobPositionInPhase)'
@@ -161,7 +165,7 @@ jobs:
   - script: |
       npm ci
       npm run build
-      node dist/postGithubComments ${{ parameters.ENTRYPOINT }} ${{ parameters.REQUESTING_USER }} ${{ parameters.SOURCE_ISSUE }} ${{ parameters.STATUS_COMMENT }} ${{ parameters.DISTINCT_ID }} ${{ parameters.TOP_REPOS }} '$(Pipeline.Workspace)' '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=artifacts&type=publishedArtifacts' ${{ parameters.POST_RESULT }} ${{ parameters.REPO_COUNT }} '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_apis/build/builds/$(Build.BuildId)/artifacts'
+      node dist/postGithubComments ${{ variables.effectiveEntrypoint }} ${{ parameters.REQUESTING_USER }} ${{ parameters.SOURCE_ISSUE }} ${{ parameters.STATUS_COMMENT }} ${{ parameters.DISTINCT_ID }} ${{ parameters.TOP_REPOS }} '$(Pipeline.Workspace)' '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=artifacts&type=publishedArtifacts' ${{ parameters.POST_RESULT }} ${{ parameters.REPO_COUNT }} '$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_apis/build/builds/$(Build.BuildId)/artifacts'
     displayName: 'Update PR comment with new errors'
     env:
       GITHUB_PAT: $(typescript-bot-github-PAT-error-deltas)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1292,9 +1292,6 @@ async function downloadTsAsync(cwd: string, params: GitParams | UserParams): Pro
     const entrypoint = params.entrypoint;
     if (params.testType === "user") {
         console.log("running user test, downloading TS from repo");
-        if (params.entrypoint === "lsp") {
-            throw new Error("Not implemented");
-        }
         const { tsEntrypointPath: oldTsEntrypointPath, resolvedVersion: oldTsResolvedVersion } = await downloadTsRepoAsync(cwd, params.oldTsRepoUrl, params.oldHeadRef, entrypoint);
         // We need to handle the ref/pull/*/merge differently as it is not a branch and cannot be pulled during clone.
         const { tsEntrypointPath: newTsEntrypointPath, resolvedVersion: newTsResolvedVersion } = await downloadTsPrAsync(cwd, params.oldTsRepoUrl, params.prNumber, entrypoint);


### PR DESCRIPTION
Uses the structure @gabritto set up for the fuzzer to allow manually triggered "tsserver" user tests to run (aka `test tsserver top###`)

I decided to continue calling them "tsserver" for the `ENTRYPOINT` parameter for simplicity, so that the pipeline (and bot) need less changes. The two entrypoint parameters continue to be `tsc` and `tsserver`, and if it's `tsserver`, the correct lsp vs tsserver infrastructure is chosen based on if we're testing tsgo or not.

(I'm also open to _not_ doing that and making the changes in the pipeline interface/bot call to explicitly specify `lsp` or have them be aliases, etc, but I didn't have super strong opinions either way)

I don't believe this conflicts with/doubles up anything included in #210