### PR TITLE
Strip BOM from files after reading

### DIFF
--- a/src/utils/exerciseLspServer.ts
+++ b/src/utils/exerciseLspServer.ts
@@ -347,7 +347,12 @@ async function exerciseLspServerWorker(testDir: string, lspServerPath: string, r
 
             openFileUris.push(openFileUri);
 
-            const openFileContents = await fs.promises.readFile(openFileAbsolutePath, { encoding: "utf-8" });
+            let openFileContents = await fs.promises.readFile(openFileAbsolutePath, { encoding: "utf-8" });
+            // Strip BOM to match VS Code behavior — VS Code never includes
+            // the BOM in textDocument.getText() / didOpen text content.
+            if (openFileContents.charCodeAt(0) === 0xFEFF) {
+                openFileContents = openFileContents.slice(1);
+            }
             const languageId = getLanguageId(openFileAbsolutePath);
             documentVersion++;
 

--- a/src/utils/exerciseServer.ts
+++ b/src/utils/exerciseServer.ts
@@ -178,7 +178,12 @@ async function exerciseServerWorker(testDir: string, tsserverPath: string, repla
 
             openFileAbsolutePaths.push(openFileAbsolutePath);
 
-            const openFileContents = await fs.promises.readFile(openFileRelativePath, { encoding: "utf-8" });
+            let openFileContents = await fs.promises.readFile(openFileRelativePath, { encoding: "utf-8" });
+            // Strip BOM to match VS Code behavior — VS Code never includes
+            // the BOM in textDocument.getText() / didOpen text content.
+            if (openFileContents.charCodeAt(0) === 0xFEFF) {
+                openFileContents = openFileContents.slice(1);
+            }
             await message({
                 "command": "updateOpen",
                 "arguments": {


### PR DESCRIPTION
VS Code strips this, and so does tsserver/tsgo when reading from disk. Sending the BOM over causes bad behaviors.

https://github.com/microsoft/vscode/blob/ea91ac3285ad7dcf0d9d259e856a952c674ce9a9/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBufferBuilder.ts#L105