### PR TITLE
Add init option enabling panic-on-flake to lsp server initialize

### DIFF
--- a/src/utils/exerciseLspServer.ts
+++ b/src/utils/exerciseLspServer.ts
@@ -178,6 +178,9 @@ async function exerciseLspServerWorker(testDir: string, lspServerPath: string, r
     // Initialize the server
     const initializeParams: protocol.InitializeParams = {
         processId: null,
+        initializationOptions: {
+            trackFlakyDiagnostics: 2,
+        },
         capabilities: {
             textDocument: {
                 completion: {


### PR DESCRIPTION
From [this PR](https://github.com/microsoft/typescript-go/pull/4710), this should get the error deltas collecting panics for inconsistently issued diagnostics.