### PR TITLE
Support migrated TS 7 repo

### DIFF
--- a/azure-pipelines-userTests.yml
+++ b/azure-pipelines-userTests.yml
@@ -134,7 +134,6 @@ jobs:
     inputs:
       version: '1.26'
     displayName: 'Install Go'
-    condition: contains('${{ parameters.OLD_TS_REPO_URL }}', 'typescript-go')
   - script: |
       df -h
       df -h -i

--- a/src/checkReposScheduled.ts
+++ b/src/checkReposScheduled.ts
@@ -23,7 +23,7 @@ mainAsync({
     newTsNpmVersion,
     resultDirName,
     prngSeed: prngSeed.toLowerCase() === "n/a" ? undefined : prngSeed,
-    implementationHint: "corsa",
+    candidateImplementation: "corsa",
 }).catch(err => {
     reportError(err, "Unhandled exception");
     process.exit(1);

--- a/src/checkReposScheduled.ts
+++ b/src/checkReposScheduled.ts
@@ -23,7 +23,6 @@ mainAsync({
     newTsNpmVersion,
     resultDirName,
     prngSeed: prngSeed.toLowerCase() === "n/a" ? undefined : prngSeed,
-    candidateImplementation: "corsa",
 }).catch(err => {
     reportError(err, "Unhandled exception");
     process.exit(1);

--- a/src/checkReposScheduled.ts
+++ b/src/checkReposScheduled.ts
@@ -23,7 +23,7 @@ mainAsync({
     newTsNpmVersion,
     resultDirName,
     prngSeed: prngSeed.toLowerCase() === "n/a" ? undefined : prngSeed,
-    isGo: true,
+    implementationHint: "corsa",
 }).catch(err => {
     reportError(err, "Unhandled exception");
     process.exit(1);

--- a/src/checkReposTriggered.ts
+++ b/src/checkReposTriggered.ts
@@ -24,7 +24,7 @@ mainAsync({
     resultDirName,
     diagnosticOutput: diagnosticOutput.toLowerCase() === "true",
     prngSeed: prngSeed.toLowerCase() === "n/a" ? undefined : prngSeed,
-    isGo: oldTsRepoUrl.includes("typescript-go")
+    implementationHint: oldTsRepoUrl.includes("typescript-go") ? "corsa" : "strada"
 }).catch(err => {
     reportError(err, "Unhandled exception");
     process.exit(1);

--- a/src/checkReposTriggered.ts
+++ b/src/checkReposTriggered.ts
@@ -24,7 +24,6 @@ mainAsync({
     resultDirName,
     diagnosticOutput: diagnosticOutput.toLowerCase() === "true",
     prngSeed: prngSeed.toLowerCase() === "n/a" ? undefined : prngSeed,
-    implementationHint: oldTsRepoUrl.includes("typescript-go") ? "corsa" : "strada"
 }).catch(err => {
     reportError(err, "Unhandled exception");
     process.exit(1);

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,8 +57,8 @@ interface Params {
      */
     prngSeed: string | undefined;
 
-    /** True if the candidate is known to be tsgo without checking out a repository. */
-    isGo: boolean;
+    /** Candidate implementation hint for sources that cannot be detected from a checkout. */
+    implementationHint: TypeScriptImplementation;
 }
 export interface ScheduledParams extends Params {
     testType: "scheduled";
@@ -73,6 +73,7 @@ export interface TriggeredParams extends Params {
 }
 
 export type TsEntrypoint = "tsc" | "tsserver" | "fuzzer";
+export type TypeScriptImplementation = "strada" | "corsa";
 
 const processCwd = process.cwd();
 const packageTimeout = 10 * 60 * 1000;
@@ -217,8 +218,9 @@ async function getTsServerRepoResult(
     rawErrorArtifactPath: string,
     diagnosticOutput: boolean,
     isPr: boolean,
-    isGo: boolean,
+    implementation: TypeScriptImplementation,
 ): Promise<RepoResult> {
+    const isCorsa = implementation === "corsa";
 
     if (!await cloneRepo(repo, userTestsDir, downloadDir.path, diagnosticOutput)) {
         return { status: "Git clone failed" };
@@ -252,7 +254,7 @@ async function getTsServerRepoResult(
     try {
         console.log(`Testing with ${newTsServerPath} (new)`);
 
-        const newSpawnResult = isGo ?
+        const newSpawnResult = isCorsa ?
             await spawnWithTimeoutAsync(repoDir, process.argv[0], [path.join(__dirname, "utils", "exerciseLspServer.js"), repoDir, replayScriptPath, newTsServerPath, diagnosticOutput.toString(), prng.string(10), "n/a"], executionTimeout) :
             await spawnWithTimeoutAsync(repoDir, process.argv[0], [path.join(__dirname, "utils", "exerciseServer.js"), repoDir, replayScriptPath, newTsServerPath, diagnosticOutput.toString(), prng.string(10)], executionTimeout);
 
@@ -278,7 +280,7 @@ async function getTsServerRepoResult(
                 console.log("No issues found");
                 break;
             case exercise.EXIT_LANGUAGE_SERVICE_DISABLED:
-                if (!isGo) {
+                if (!isCorsa) {
                     console.log("Skipping since language service was disabled");
                     return { status: "Language service disabled in new TS" };
                 }
@@ -302,13 +304,13 @@ async function getTsServerRepoResult(
 
         if (newServerFailed) {
             console.log(`Issue found in ${newTsServerPath} (new):`);
-            const harnessOutput = isGo ? prettyPrintLspHarnessOutput(newSpawnResult.stdout, /*filter*/ false) : prettyPrintServerHarnessOutput(newSpawnResult.stdout, /*filter*/ false);
+            const harnessOutput = isCorsa ? prettyPrintLspHarnessOutput(newSpawnResult.stdout, /*filter*/ false) : prettyPrintServerHarnessOutput(newSpawnResult.stdout, /*filter*/ false);
             console.log(insetLines(harnessOutput));
             await fs.promises.writeFile(rawErrorPath, harnessOutput);
         }
 
         console.log(`Testing with ${oldTsServerPath} (old)`);
-        const oldSpawnResult = isGo ?
+        const oldSpawnResult = isCorsa ?
             await spawnWithTimeoutAsync(repoDir, process.argv[0], [path.join(__dirname, "utils", "replayLspServer.js"), repoDir, replayScriptPath, oldTsServerPath, diagnosticOutput.toString()], executionTimeout) :
             await spawnWithTimeoutAsync(repoDir, process.argv[0], [path.join(__dirname, "..", "node_modules", "@typescript", "server-replay", "bin", "tsreplay.js"), "strada-replay", repoDir, replayScriptPath, oldTsServerPath, "-u"], executionTimeout);
 
@@ -326,7 +328,7 @@ async function getTsServerRepoResult(
 
         if (oldServerFailed) {
             const oldHarnessOutput = oldSpawnResult?.stdout &&
-                (isGo ?
+                (isCorsa ?
                     prettyPrintLspHarnessOutput(oldSpawnResult.stdout, /*filter*/ false) :
                     prettyPrintServerHarnessOutput(oldSpawnResult.stdout, /*filter*/ false));
             console.log(`Issue found in ${oldTsServerPath} (old):`);
@@ -339,7 +341,7 @@ async function getTsServerRepoResult(
             // We don't want to drown PRs with comments.
             // Override the results to say nothing interesting changed.
             if (isPr && newServerFailed && oldSpawnResult) {
-                if (isGo) {
+                if (isCorsa) {
                     const oldOut = parseLspHarnessOutput(oldSpawnResult.stdout);
                     const newOut = parseLspHarnessOutput(newSpawnResult.stdout);
                     if (
@@ -495,7 +497,8 @@ export async function getLSPResult(
     }
 }
 
-function groupErrors(summaries: Summary[], isGo: boolean) {
+function groupErrors(summaries: Summary[], implementation: TypeScriptImplementation) {
+    const isCorsa = implementation === "corsa";
     const groupedOldErrors = new Map<string, Summary[]>();
     const groupedNewErrors = new Map<string, Summary[]>();
     let group: Map<string, Summary[]>;
@@ -503,7 +506,7 @@ function groupErrors(summaries: Summary[], isGo: boolean) {
     for (const summary of summaries) {
         if (summary.tsServerResult.newServerFailed) {
             // Group new errors
-            error = isGo
+            error = isCorsa
                 ? parseLspHarnessOutput(summary.tsServerResult.newSpawnResult.stdout)
                 : parseServerHarnessOutput(summary.tsServerResult.newSpawnResult.stdout);
             group = groupedNewErrors;
@@ -512,7 +515,7 @@ function groupErrors(summaries: Summary[], isGo: boolean) {
             // Group old errors
             const { oldSpawnResult } = summary.tsServerResult;
             error = oldSpawnResult?.stdout
-                ? (isGo ? parseLspHarnessOutput(oldSpawnResult.stdout) : parseServerHarnessOutput(oldSpawnResult.stdout))
+                ? (isCorsa ? parseLspHarnessOutput(oldSpawnResult.stdout) : parseServerHarnessOutput(oldSpawnResult.stdout))
                 : `Timed out after ${executionTimeout} ms`;
 
             group = groupedOldErrors;
@@ -523,7 +526,7 @@ function groupErrors(summaries: Summary[], isGo: boolean) {
 
         const key = typeof error === "string"
             ? getHash([error])
-            : isGo
+            : isCorsa
                 ? getHashForGoStack(error.message)
                 : getHashForStack(error.message);
         const value = group.get(key) ?? [];
@@ -540,12 +543,12 @@ function getJSErrorMessage(output: string): string {
     return typeof error === "string" ? error : getErrorMessageFromStack(error.message);
 }
 
-function getErrorMessage(output: string, isGo: boolean): string {
-    return isGo ? getLspErrorMessage(output) : getJSErrorMessage(output);
+function getErrorMessage(output: string, implementation: TypeScriptImplementation): string {
+    return implementation === "corsa" ? getLspErrorMessage(output) : getJSErrorMessage(output);
 }
 
-function prettyPrint(output: string, filter: boolean, isGo: boolean): string {
-    return isGo ? prettyPrintLspHarnessOutput(output, filter) : prettyPrintServerHarnessOutput(output, filter);
+function prettyPrint(output: string, filter: boolean, implementation: TypeScriptImplementation): string {
+    return implementation === "corsa" ? prettyPrintLspHarnessOutput(output, filter) : prettyPrintServerHarnessOutput(output, filter);
 }
 
 function getReplayInstructions(summary: Summary): string {
@@ -587,14 +590,14 @@ To run the repro, use the "Launch replay test" launch configuration in your loca
     return text;
 }
 
-function createOldErrorSummary(summaries: Summary[], isGo: boolean): string {
+function createOldErrorSummary(summaries: Summary[], implementation: TypeScriptImplementation): string {
     const { oldSpawnResult } = summaries[0].tsServerResult;
 
     const oldServerError = oldSpawnResult?.stdout
-        ? prettyPrint(oldSpawnResult.stdout, /*filter*/ true, isGo)
+        ? prettyPrint(oldSpawnResult.stdout, /*filter*/ true, implementation)
         : `Timed out after ${executionTimeout} ms`;
 
-    const errorMessage = oldSpawnResult?.stdout ? getErrorMessage(oldSpawnResult.stdout, isGo) : oldServerError;
+    const errorMessage = oldSpawnResult?.stdout ? getErrorMessage(oldSpawnResult.stdout, implementation) : oldServerError;
 
     let text = `
 <details>
@@ -632,13 +635,13 @@ ${summary.replayScript}
     return text;
 }
 
-async function createNewErrorSummaryAsync(summaries: Summary[], isGo: boolean): Promise<string> {
+async function createNewErrorSummaryAsync(summaries: Summary[], implementation: TypeScriptImplementation): Promise<string> {
     const stdout = summaries[0].tsServerResult.newSpawnResult.stdout;
 
-    let text = `<h2>${getErrorMessage(stdout, isGo)}</h2>
+    let text = `<h2>${getErrorMessage(stdout, implementation)}</h2>
 
 \`\`\`
-${prettyPrint(stdout, /*filter*/ true, isGo)}
+${prettyPrint(stdout, /*filter*/ true, implementation)}
 \`\`\`
 
 <h4>Affected repos</h4>`;
@@ -667,7 +670,7 @@ Replay commands: <code>${summary.replayScriptArtifactPath}</code> in the <a href
 `;
         }
         else {
-            const oldHarnessOutput = prettyPrint(oldSpawnResult.stdout, /*filter*/ true, isGo);
+            const oldHarnessOutput = prettyPrint(oldSpawnResult.stdout, /*filter*/ true, implementation);
             text += `<h4>Old server result</h4>
 
 \`\`\`
@@ -947,7 +950,7 @@ export async function mainAsync(params: ScheduledParams | TriggeredParams): Prom
     }
 
     // TODO: Only download if the commit has changed (need to map refs to commits and then download to typescript-COMMIT instead)
-    const { oldTsEntrypointPath, oldTsResolvedVersion, newTsEntrypointPath, newTsResolvedVersion, isGo } = await downloadTsAsync(processCwd, params);
+    const { oldTsEntrypointPath, oldTsResolvedVersion, newTsEntrypointPath, newTsResolvedVersion, implementation } = await downloadTsAsync(processCwd, params);
 
     // Get the name of the typescript folder.
     const oldTscDirPath = oldTsEntrypointPath && path.resolve(oldTsEntrypointPath, "../../");
@@ -992,7 +995,7 @@ export async function mainAsync(params: ScheduledParams | TriggeredParams): Prom
                 repoResult = await getTscRepoResult(repo, userTestsDir, oldTsEntrypointPath!, newTsEntrypointPath, params.buildWithNewWhenOldFails, downloadDir, diagnosticOutput);
                 break;
             case "tsserver":
-                repoResult = await getTsServerRepoResult(repo, userTestsDir, oldTsEntrypointPath!, newTsEntrypointPath, downloadDir, replayScriptArtifactPath, rawErrorArtifactPath, diagnosticOutput, isPr, isGo);
+                repoResult = await getTsServerRepoResult(repo, userTestsDir, oldTsEntrypointPath!, newTsEntrypointPath, downloadDir, replayScriptArtifactPath, rawErrorArtifactPath, diagnosticOutput, isPr, implementation);
                 break;
             case "fuzzer":
                 repoResult = await getLSPResult(repo, userTestsDir, newTsEntrypointPath, downloadDir, replayScriptArtifactPath, rawErrorArtifactPath, diagnosticOutput);
@@ -1055,17 +1058,17 @@ export async function mainAsync(params: ScheduledParams | TriggeredParams): Prom
 
     // Group errors and create summary files.
     if (summaries.length > 0) {
-        const { groupedOldErrors, groupedNewErrors } = groupErrors(summaries, isGo);
+        const { groupedOldErrors, groupedNewErrors } = groupErrors(summaries, implementation);
 
         for (let [key, value] of groupedOldErrors) {
-            const summary = createOldErrorSummary(value, isGo);
+            const summary = createOldErrorSummary(value, implementation);
             const resultFileName = `!${key}.${resultFileNameSuffix}`; // Exclamation point makes the file to be put first when ordering.
 
             await fs.promises.writeFile(path.join(resultDirPath, resultFileName), summary, { encoding: "utf-8" });
         }
 
         for (let [key, value] of groupedNewErrors) {
-            const summary = await createNewErrorSummaryAsync(value, isGo);
+            const summary = await createNewErrorSummaryAsync(value, implementation);
             const resultFileName = `${key}.${resultFileNameSuffix}`;
 
             await fs.promises.writeFile(path.join(resultDirPath, resultFileName), summary, { encoding: "utf-8" });
@@ -1249,21 +1252,21 @@ function makeMarkdownLink(url: string) {
 interface DownloadedTs {
     tsEntrypointPath: string;
     resolvedVersion: string;
-    isGo: boolean;
+    implementation: TypeScriptImplementation;
 }
 
-async function downloadTsAsync(cwd: string, params: ScheduledParams | TriggeredParams): Promise<{ oldTsEntrypointPath: string | undefined, oldTsResolvedVersion: string | undefined, newTsEntrypointPath: string, newTsResolvedVersion: string, isGo: boolean }> {
+async function downloadTsAsync(cwd: string, params: ScheduledParams | TriggeredParams): Promise<{ oldTsEntrypointPath: string | undefined, oldTsResolvedVersion: string | undefined, newTsEntrypointPath: string, newTsResolvedVersion: string, implementation: TypeScriptImplementation }> {
     const entrypoint = params.entrypoint;
     if (params.testType === "triggered") {
         console.log("running user test, downloading TS from repo");
         if (params.entrypoint === "fuzzer") {
             throw new Error("Not implemented");
         }
-        const { tsEntrypointPath: oldTsEntrypointPath, resolvedVersion: oldTsResolvedVersion, isGo: oldIsGo } = await downloadTsRepoAsync(cwd, params.oldTsRepoUrl, params.oldHeadRef, entrypoint, params.isGo);
+        const { tsEntrypointPath: oldTsEntrypointPath, resolvedVersion: oldTsResolvedVersion, implementation: oldImplementation } = await downloadTsRepoAsync(cwd, params.oldTsRepoUrl, params.oldHeadRef, entrypoint, params.implementationHint);
         // We need to handle the ref/pull/*/merge differently as it is not a branch and cannot be pulled during clone.
-        const { tsEntrypointPath: newTsEntrypointPath, resolvedVersion: newTsResolvedVersion, isGo } = await downloadTsPrAsync(cwd, params.oldTsRepoUrl, params.prNumber, entrypoint, params.isGo);
+        const { tsEntrypointPath: newTsEntrypointPath, resolvedVersion: newTsResolvedVersion, implementation } = await downloadTsPrAsync(cwd, params.oldTsRepoUrl, params.prNumber, entrypoint, params.implementationHint);
 
-        if (entrypoint === "tsserver" && oldIsGo !== isGo) {
+        if (entrypoint === "tsserver" && oldImplementation !== implementation) {
             throw new Error("Cannot compare tsserver refs across the TypeScript-to-tsgo migration boundary");
         }
 
@@ -1272,18 +1275,18 @@ async function downloadTsAsync(cwd: string, params: ScheduledParams | TriggeredP
             oldTsResolvedVersion,
             newTsEntrypointPath,
             newTsResolvedVersion,
-            isGo
+            implementation
         };
     }
     else if (params.testType === "scheduled") {
         const { tsEntrypointPath: oldTsEntrypointPath, resolvedVersion: oldTsResolvedVersion } = params.entrypoint === "fuzzer" ?
             { tsEntrypointPath: undefined, resolvedVersion: undefined } :
             await downloadTsNpmAsync(cwd, params.oldTsNpmVersion, entrypoint);
-        const { tsEntrypointPath: newTsEntrypointPath, resolvedVersion: newTsResolvedVersion, isGo } = params.entrypoint === "fuzzer" ?
+        const { tsEntrypointPath: newTsEntrypointPath, resolvedVersion: newTsResolvedVersion, implementation } = params.entrypoint === "fuzzer" ?
             params.newTsNpmVersion === "main" ?
-                await downloadTsRepoAsync(cwd, "https://github.com/microsoft/typescript-go.git", /*headRef*/ "main", entrypoint, params.isGo) :
+                await downloadTsRepoAsync(cwd, "https://github.com/microsoft/typescript-go.git", /*headRef*/ "main", entrypoint, params.implementationHint) :
                 await downloadTsNativePreviewNpmAsync(cwd, params.newTsNpmVersion) :
-            params.isGo ?
+            params.implementationHint === "corsa" ?
                 await downloadTsNativePreviewNpmAsync(cwd, params.newTsNpmVersion) :
                 await downloadTsNpmAsync(cwd, params.newTsNpmVersion, entrypoint);
 
@@ -1292,7 +1295,7 @@ async function downloadTsAsync(cwd: string, params: ScheduledParams | TriggeredP
             oldTsResolvedVersion,
             newTsEntrypointPath,
             newTsResolvedVersion,
-            isGo
+            implementation
         };
     }
     else {
@@ -1300,25 +1303,25 @@ async function downloadTsAsync(cwd: string, params: ScheduledParams | TriggeredP
     }
 }
 
-export async function downloadTsRepoAsync(cwd: string, repoUrl: string, headRef: string, target: TsEntrypoint, isGoHint: boolean): Promise<DownloadedTs> {
+export async function downloadTsRepoAsync(cwd: string, repoUrl: string, headRef: string, target: TsEntrypoint, implementationHint: TypeScriptImplementation): Promise<DownloadedTs> {
     console.log(`Cloning ${repoUrl} at ref ${headRef}`);
-    const repoName = isGoHint ? `typescript-go-${headRef}` : `typescript-${headRef}`;
+    const repoName = implementationHint === "corsa" ? `typescript-go-${headRef}` : `typescript-${headRef}`;
     await git.cloneRepoIfNecessary(cwd, { name: repoName, url: repoUrl, branch: headRef });
 
     const repoPath = path.join(cwd, repoName);
-    const { tsEntrypointPath, isGo } = await buildTs(repoPath, target);
+    const { tsEntrypointPath, implementation } = await buildTs(repoPath, target);
 
     return {
         tsEntrypointPath,
         resolvedVersion: headRef,
-        isGo
+        implementation
     };
 }
 
-async function downloadTsPrAsync(cwd: string, repoUrl: string, prNumber: number, target: TsEntrypoint, isGoHint: boolean): Promise<DownloadedTs> {
+async function downloadTsPrAsync(cwd: string, repoUrl: string, prNumber: number, target: TsEntrypoint, implementationHint: TypeScriptImplementation): Promise<DownloadedTs> {
     console.log(`Cloning ${repoUrl} at pull ${prNumber}`);
 
-    const repoName = isGoHint ? `typescript-go-${prNumber}` : `typescript-${prNumber}`;
+    const repoName = implementationHint === "corsa" ? `typescript-go-${prNumber}` : `typescript-${prNumber}`;
     console.log(`Building in ${repoName}`);
 
     await git.cloneRepoIfNecessary(cwd, { name: repoName, url: repoUrl });
@@ -1327,28 +1330,28 @@ async function downloadTsPrAsync(cwd: string, repoUrl: string, prNumber: number,
     const headRef = `refs/pull/${prNumber}/merge`;
 
     await git.checkout(repoPath, headRef);
-    const { tsEntrypointPath, isGo } = await buildTs(repoPath, target);
+    const { tsEntrypointPath, implementation } = await buildTs(repoPath, target);
 
     return {
         tsEntrypointPath,
         resolvedVersion: headRef,
-        isGo
+        implementation
     };
 }
 
-export function isTsgoPackage(packageJson: { name?: string }): boolean {
-    return packageJson.name !== "typescript";
+export function detectTypeScriptImplementation(packageJson: { name?: string }): TypeScriptImplementation {
+    return packageJson.name === "typescript" ? "strada" : "corsa";
 }
 
-async function buildTs(repoPath: string, entrypoint: TsEntrypoint): Promise<{ tsEntrypointPath: string, isGo: boolean }> {
+async function buildTs(repoPath: string, entrypoint: TsEntrypoint): Promise<{ tsEntrypointPath: string, implementation: TypeScriptImplementation }> {
     const packageJsonPath = path.join(repoPath, "package.json");
     const packageJson = JSON.parse(await fs.promises.readFile(packageJsonPath, { encoding: "utf-8" })) as { name?: string };
-    const isGo = isTsgoPackage(packageJson);
+    const implementation = detectTypeScriptImplementation(packageJson);
 
     await execAsync(repoPath, "npm ci");
     console.log(`Building in ${repoPath}`);
 
-    if (isGo) {
+    if (implementation === "corsa") {
         await execAsync(repoPath, `npx hereby build`);
         const candidates = [
             path.join(repoPath, "built", "local", "tsc"),
@@ -1356,7 +1359,7 @@ async function buildTs(repoPath: string, entrypoint: TsEntrypoint): Promise<{ ts
         ];
         for (const tsEntrypointPath of candidates) {
             if (await pu.exists(tsEntrypointPath)) {
-                return { tsEntrypointPath, isGo };
+                return { tsEntrypointPath, implementation };
             }
         }
         throw new Error(`Cannot find tsgo entrypoint in ${path.join(repoPath, "built", "local")}`);
@@ -1370,7 +1373,7 @@ async function buildTs(repoPath: string, entrypoint: TsEntrypoint): Promise<{ ts
             await execAsync(repoPath, "npx gulp LKG");
         }
 
-        return { tsEntrypointPath: path.join(repoPath, "built", "local", `${entrypoint}.js`), isGo };
+        return { tsEntrypointPath: path.join(repoPath, "built", "local", `${entrypoint}.js`), implementation };
     }
 }
 
@@ -1394,7 +1397,7 @@ async function downloadTsNpmAsync(cwd: string, version: string, entrypoint: TsEn
         throw new Error("Cannot find file " + tsEntrypointPath);
     }
 
-    return { tsEntrypointPath, resolvedVersion, isGo: false };
+    return { tsEntrypointPath, resolvedVersion, implementation: "strada" };
 }
 
 async function downloadTsNativePreviewNpmAsync(cwd: string, version: string): Promise<DownloadedTs> {
@@ -1418,5 +1421,5 @@ async function downloadTsNativePreviewNpmAsync(cwd: string, version: string): Pr
         throw new Error("Cannot find file " + tsEntrypointPath);
     }
 
-    return { tsEntrypointPath, resolvedVersion, isGo: true };
+    return { tsEntrypointPath, resolvedVersion, implementation: "corsa" };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,13 +57,12 @@ interface Params {
      */
     prngSeed: string | undefined;
 
-    /** Candidate implementation hint for sources that cannot be detected from a checkout. */
-    implementationHint: TypeScriptImplementation;
 }
 export interface ScheduledParams extends Params {
     testType: "scheduled";
     oldTsNpmVersion: string;
     newTsNpmVersion: string;
+    candidateImplementation: TypeScriptImplementation;
 }
 export interface TriggeredParams extends Params {
     testType: "triggered";
@@ -1262,9 +1261,9 @@ async function downloadTsAsync(cwd: string, params: ScheduledParams | TriggeredP
         if (params.entrypoint === "fuzzer") {
             throw new Error("Not implemented");
         }
-        const { tsEntrypointPath: oldTsEntrypointPath, resolvedVersion: oldTsResolvedVersion, implementation: oldImplementation } = await downloadTsRepoAsync(cwd, params.oldTsRepoUrl, params.oldHeadRef, entrypoint, params.implementationHint);
+        const { tsEntrypointPath: oldTsEntrypointPath, resolvedVersion: oldTsResolvedVersion, implementation: oldImplementation } = await downloadTsRepoAsync(cwd, params.oldTsRepoUrl, params.oldHeadRef, entrypoint);
         // We need to handle the ref/pull/*/merge differently as it is not a branch and cannot be pulled during clone.
-        const { tsEntrypointPath: newTsEntrypointPath, resolvedVersion: newTsResolvedVersion, implementation } = await downloadTsPrAsync(cwd, params.oldTsRepoUrl, params.prNumber, entrypoint, params.implementationHint);
+        const { tsEntrypointPath: newTsEntrypointPath, resolvedVersion: newTsResolvedVersion, implementation } = await downloadTsPrAsync(cwd, params.oldTsRepoUrl, params.prNumber, entrypoint);
 
         if (entrypoint === "tsserver" && oldImplementation !== implementation) {
             throw new Error("Cannot compare tsserver refs across the TypeScript-to-tsgo migration boundary");
@@ -1284,9 +1283,9 @@ async function downloadTsAsync(cwd: string, params: ScheduledParams | TriggeredP
             await downloadTsNpmAsync(cwd, params.oldTsNpmVersion, entrypoint);
         const { tsEntrypointPath: newTsEntrypointPath, resolvedVersion: newTsResolvedVersion, implementation } = params.entrypoint === "fuzzer" ?
             params.newTsNpmVersion === "main" ?
-                await downloadTsRepoAsync(cwd, "https://github.com/microsoft/typescript-go.git", /*headRef*/ "main", entrypoint, params.implementationHint) :
+                await downloadTsRepoAsync(cwd, "https://github.com/microsoft/typescript-go.git", /*headRef*/ "main", entrypoint) :
                 await downloadTsNativePreviewNpmAsync(cwd, params.newTsNpmVersion) :
-            params.implementationHint === "corsa" ?
+            params.candidateImplementation === "corsa" ?
                 await downloadTsNativePreviewNpmAsync(cwd, params.newTsNpmVersion) :
                 await downloadTsNpmAsync(cwd, params.newTsNpmVersion, entrypoint);
 
@@ -1303,9 +1302,14 @@ async function downloadTsAsync(cwd: string, params: ScheduledParams | TriggeredP
     }
 }
 
-export async function downloadTsRepoAsync(cwd: string, repoUrl: string, headRef: string, target: TsEntrypoint, implementationHint: TypeScriptImplementation): Promise<DownloadedTs> {
+function getTsRepoDownloadName(repoUrl: string, ref: string): string {
+    const repoName = path.basename(repoUrl).replace(/\.git$/, "").toLowerCase();
+    return `${repoName}-${ref}`;
+}
+
+export async function downloadTsRepoAsync(cwd: string, repoUrl: string, headRef: string, target: TsEntrypoint): Promise<DownloadedTs> {
     console.log(`Cloning ${repoUrl} at ref ${headRef}`);
-    const repoName = implementationHint === "corsa" ? `typescript-go-${headRef}` : `typescript-${headRef}`;
+    const repoName = getTsRepoDownloadName(repoUrl, headRef);
     await git.cloneRepoIfNecessary(cwd, { name: repoName, url: repoUrl, branch: headRef });
 
     const repoPath = path.join(cwd, repoName);
@@ -1318,10 +1322,10 @@ export async function downloadTsRepoAsync(cwd: string, repoUrl: string, headRef:
     };
 }
 
-async function downloadTsPrAsync(cwd: string, repoUrl: string, prNumber: number, target: TsEntrypoint, implementationHint: TypeScriptImplementation): Promise<DownloadedTs> {
+async function downloadTsPrAsync(cwd: string, repoUrl: string, prNumber: number, target: TsEntrypoint): Promise<DownloadedTs> {
     console.log(`Cloning ${repoUrl} at pull ${prNumber}`);
 
-    const repoName = implementationHint === "corsa" ? `typescript-go-${prNumber}` : `typescript-${prNumber}`;
+    const repoName = getTsRepoDownloadName(repoUrl, prNumber.toString());
     console.log(`Building in ${repoName}`);
 
     await git.cloneRepoIfNecessary(cwd, { name: repoName, url: repoUrl });

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,7 +62,6 @@ export interface ScheduledParams extends Params {
     testType: "scheduled";
     oldTsNpmVersion: string;
     newTsNpmVersion: string;
-    candidateImplementation: TypeScriptImplementation;
 }
 export interface TriggeredParams extends Params {
     testType: "triggered";
@@ -1278,16 +1277,17 @@ async function downloadTsAsync(cwd: string, params: ScheduledParams | TriggeredP
         };
     }
     else if (params.testType === "scheduled") {
-        const { tsEntrypointPath: oldTsEntrypointPath, resolvedVersion: oldTsResolvedVersion } = params.entrypoint === "fuzzer" ?
-            { tsEntrypointPath: undefined, resolvedVersion: undefined } :
+        const { tsEntrypointPath: oldTsEntrypointPath, resolvedVersion: oldTsResolvedVersion, implementation: oldImplementation } = params.entrypoint === "fuzzer" ?
+            { tsEntrypointPath: undefined, resolvedVersion: undefined, implementation: undefined } :
             await downloadTsNpmAsync(cwd, params.oldTsNpmVersion, entrypoint);
-        const { tsEntrypointPath: newTsEntrypointPath, resolvedVersion: newTsResolvedVersion, implementation } = params.entrypoint === "fuzzer" ?
-            params.newTsNpmVersion === "main" ?
+        const { tsEntrypointPath: newTsEntrypointPath, resolvedVersion: newTsResolvedVersion, implementation } =
+            params.entrypoint === "fuzzer" && params.newTsNpmVersion === "main" ?
                 await downloadTsRepoAsync(cwd, "https://github.com/microsoft/typescript-go.git", /*headRef*/ "main", entrypoint) :
-                await downloadTsNativePreviewNpmAsync(cwd, params.newTsNpmVersion) :
-            params.candidateImplementation === "corsa" ?
-                await downloadTsNativePreviewNpmAsync(cwd, params.newTsNpmVersion) :
                 await downloadTsNpmAsync(cwd, params.newTsNpmVersion, entrypoint);
+
+        if (entrypoint === "tsserver" && oldImplementation !== implementation) {
+            throw new Error("Cannot compare tsserver versions across the TypeScript-to-tsgo migration boundary");
+        }
 
         return {
             oldTsEntrypointPath,
@@ -1347,6 +1347,12 @@ export function detectTypeScriptImplementation(packageJson: { name?: string }): 
     return packageJson.name === "typescript" ? "strada" : "corsa";
 }
 
+export function detectTypeScriptNpmImplementation(packageJson: { optionalDependencies?: Record<string, string> }): TypeScriptImplementation {
+    return Object.keys(packageJson.optionalDependencies ?? {}).some(name => name.startsWith("@typescript/typescript-"))
+        ? "corsa"
+        : "strada";
+}
+
 async function buildTs(repoPath: string, entrypoint: TsEntrypoint): Promise<{ tsEntrypointPath: string, implementation: TypeScriptImplementation }> {
     const packageJsonPath = path.join(repoPath, "package.json");
     const packageJson = JSON.parse(await fs.promises.readFile(packageJsonPath, { encoding: "utf-8" })) as { name?: string };
@@ -1396,34 +1402,23 @@ async function downloadTsNpmAsync(cwd: string, version: string, entrypoint: TsEn
     await execAsync(cwd, `tar xf ${tarName} && rm ${tarName}`);
     await fs.promises.rename(path.join(processCwd, "package"), dirPath);
 
-    const tsEntrypointPath = path.join(dirPath, "lib", `${entrypoint}.js`);
+    const packageJson = JSON.parse(await fs.promises.readFile(path.join(dirPath, "package.json"), { encoding: "utf-8" })) as {
+        optionalDependencies?: Record<string, string>;
+    };
+    const implementation = detectTypeScriptNpmImplementation(packageJson);
+    if (entrypoint === "fuzzer" && implementation !== "corsa") {
+        throw new Error(`TypeScript ${resolvedVersion} does not support the LSP fuzzer`);
+    }
+    if (implementation === "corsa") {
+        await execAsync(dirPath, "npm install --ignore-scripts --omit=dev --no-package-lock --silent");
+    }
+
+    const tsEntrypointPath = implementation === "corsa"
+        ? path.join(dirPath, "bin", "tsc")
+        : path.join(dirPath, "lib", `${entrypoint}.js`);
     if (!await pu.exists(tsEntrypointPath)) {
         throw new Error("Cannot find file " + tsEntrypointPath);
     }
 
-    return { tsEntrypointPath, resolvedVersion, implementation: "strada" };
-}
-
-async function downloadTsNativePreviewNpmAsync(cwd: string, version: string): Promise<DownloadedTs> {
-    const packageName = `native-preview-${process.platform}-${process.arch}`
-    const tarName = (await execAsync(cwd, `npm pack @typescript/${packageName}@${version} --quiet`)).trim();
-
-    const tarMatch = /^(typescript-native-preview-(.+))\..+$/.exec(tarName);
-    if (!tarMatch) {
-        throw new Error("Unexpected tarball name format: " + tarName);
-    }
-
-    const resolvedVersion = tarMatch[2];
-    const dirName = tarMatch[1];
-    const dirPath = path.join(processCwd, dirName);
-
-    await execAsync(cwd, `tar xf ${tarName} && rm ${tarName}`);
-    await fs.promises.rename(path.join(processCwd, "package"), dirPath);
-
-    const tsEntrypointPath = path.join(dirPath, "lib", "tsgo");
-    if (!await pu.exists(tsEntrypointPath)) {
-        throw new Error("Cannot find file " + tsEntrypointPath);
-    }
-
-    return { tsEntrypointPath, resolvedVersion, implementation: "corsa" };
+    return { tsEntrypointPath, resolvedVersion, implementation };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,7 +57,7 @@ interface Params {
      */
     prngSeed: string | undefined;
 
-    /** True if we're testing typescript-go */
+    /** True if the candidate is known to be tsgo without checking out a repository. */
     isGo: boolean;
 }
 export interface ScheduledParams extends Params {
@@ -947,7 +947,7 @@ export async function mainAsync(params: ScheduledParams | TriggeredParams): Prom
     }
 
     // TODO: Only download if the commit has changed (need to map refs to commits and then download to typescript-COMMIT instead)
-    const { oldTsEntrypointPath, oldTsResolvedVersion, newTsEntrypointPath, newTsResolvedVersion } = await downloadTsAsync(processCwd, params);
+    const { oldTsEntrypointPath, oldTsResolvedVersion, newTsEntrypointPath, newTsResolvedVersion, isGo } = await downloadTsAsync(processCwd, params);
 
     // Get the name of the typescript folder.
     const oldTscDirPath = oldTsEntrypointPath && path.resolve(oldTsEntrypointPath, "../../");
@@ -992,7 +992,7 @@ export async function mainAsync(params: ScheduledParams | TriggeredParams): Prom
                 repoResult = await getTscRepoResult(repo, userTestsDir, oldTsEntrypointPath!, newTsEntrypointPath, params.buildWithNewWhenOldFails, downloadDir, diagnosticOutput);
                 break;
             case "tsserver":
-                repoResult = await getTsServerRepoResult(repo, userTestsDir, oldTsEntrypointPath!, newTsEntrypointPath, downloadDir, replayScriptArtifactPath, rawErrorArtifactPath, diagnosticOutput, isPr, params.isGo);
+                repoResult = await getTsServerRepoResult(repo, userTestsDir, oldTsEntrypointPath!, newTsEntrypointPath, downloadDir, replayScriptArtifactPath, rawErrorArtifactPath, diagnosticOutput, isPr, isGo);
                 break;
             case "fuzzer":
                 repoResult = await getLSPResult(repo, userTestsDir, newTsEntrypointPath, downloadDir, replayScriptArtifactPath, rawErrorArtifactPath, diagnosticOutput);
@@ -1055,17 +1055,17 @@ export async function mainAsync(params: ScheduledParams | TriggeredParams): Prom
 
     // Group errors and create summary files.
     if (summaries.length > 0) {
-        const { groupedOldErrors, groupedNewErrors } = groupErrors(summaries, params.isGo);
+        const { groupedOldErrors, groupedNewErrors } = groupErrors(summaries, isGo);
 
         for (let [key, value] of groupedOldErrors) {
-            const summary = createOldErrorSummary(value, params.isGo);
+            const summary = createOldErrorSummary(value, isGo);
             const resultFileName = `!${key}.${resultFileNameSuffix}`; // Exclamation point makes the file to be put first when ordering.
 
             await fs.promises.writeFile(path.join(resultDirPath, resultFileName), summary, { encoding: "utf-8" });
         }
 
         for (let [key, value] of groupedNewErrors) {
-            const summary = await createNewErrorSummaryAsync(value, params.isGo);
+            const summary = await createNewErrorSummaryAsync(value, isGo);
             const resultFileName = `${key}.${resultFileNameSuffix}`;
 
             await fs.promises.writeFile(path.join(resultDirPath, resultFileName), summary, { encoding: "utf-8" });
@@ -1220,7 +1220,7 @@ function getLspErrorMessage(output: string): string {
 }
 
 function filterToGoLines(stackLines: string): string {
-    const goRegex = /^.*typescript-go.*$/mg;
+    const goRegex = /^.*(?:typescript-go|typescript[\\/]tsc).*$/img;
     let goLines = "";
     let match;
     while (match = goRegex.exec(stackLines)) {
@@ -1246,29 +1246,40 @@ function makeMarkdownLink(url: string) {
         : `[${mdEscape(match[1])}](${url})`;
 }
 
-async function downloadTsAsync(cwd: string, params: ScheduledParams | TriggeredParams): Promise<{ oldTsEntrypointPath: string | undefined, oldTsResolvedVersion: string | undefined, newTsEntrypointPath: string, newTsResolvedVersion: string }> {
+interface DownloadedTs {
+    tsEntrypointPath: string;
+    resolvedVersion: string;
+    isGo: boolean;
+}
+
+async function downloadTsAsync(cwd: string, params: ScheduledParams | TriggeredParams): Promise<{ oldTsEntrypointPath: string | undefined, oldTsResolvedVersion: string | undefined, newTsEntrypointPath: string, newTsResolvedVersion: string, isGo: boolean }> {
     const entrypoint = params.entrypoint;
     if (params.testType === "triggered") {
         console.log("running user test, downloading TS from repo");
         if (params.entrypoint === "fuzzer") {
             throw new Error("Not implemented");
         }
-        const { tsEntrypointPath: oldTsEntrypointPath, resolvedVersion: oldTsResolvedVersion } = await downloadTsRepoAsync(cwd, params.oldTsRepoUrl, params.oldHeadRef, entrypoint, params.isGo);
+        const { tsEntrypointPath: oldTsEntrypointPath, resolvedVersion: oldTsResolvedVersion, isGo: oldIsGo } = await downloadTsRepoAsync(cwd, params.oldTsRepoUrl, params.oldHeadRef, entrypoint, params.isGo);
         // We need to handle the ref/pull/*/merge differently as it is not a branch and cannot be pulled during clone.
-        const { tsEntrypointPath: newTsEntrypointPath, resolvedVersion: newTsResolvedVersion } = await downloadTsPrAsync(cwd, params.oldTsRepoUrl, params.prNumber, entrypoint, params.isGo);
+        const { tsEntrypointPath: newTsEntrypointPath, resolvedVersion: newTsResolvedVersion, isGo } = await downloadTsPrAsync(cwd, params.oldTsRepoUrl, params.prNumber, entrypoint, params.isGo);
+
+        if (entrypoint === "tsserver" && oldIsGo !== isGo) {
+            throw new Error("Cannot compare tsserver refs across the TypeScript-to-tsgo migration boundary");
+        }
 
         return {
             oldTsEntrypointPath,
             oldTsResolvedVersion,
             newTsEntrypointPath,
-            newTsResolvedVersion
+            newTsResolvedVersion,
+            isGo
         };
     }
     else if (params.testType === "scheduled") {
         const { tsEntrypointPath: oldTsEntrypointPath, resolvedVersion: oldTsResolvedVersion } = params.entrypoint === "fuzzer" ?
             { tsEntrypointPath: undefined, resolvedVersion: undefined } :
             await downloadTsNpmAsync(cwd, params.oldTsNpmVersion, entrypoint);
-        const { tsEntrypointPath: newTsEntrypointPath, resolvedVersion: newTsResolvedVersion } = params.entrypoint === "fuzzer" ?
+        const { tsEntrypointPath: newTsEntrypointPath, resolvedVersion: newTsResolvedVersion, isGo } = params.entrypoint === "fuzzer" ?
             params.newTsNpmVersion === "main" ?
                 await downloadTsRepoAsync(cwd, "https://github.com/microsoft/typescript-go.git", /*headRef*/ "main", entrypoint, params.isGo) :
                 await downloadTsNativePreviewNpmAsync(cwd, params.newTsNpmVersion) :
@@ -1280,7 +1291,8 @@ async function downloadTsAsync(cwd: string, params: ScheduledParams | TriggeredP
             oldTsEntrypointPath,
             oldTsResolvedVersion,
             newTsEntrypointPath,
-            newTsResolvedVersion
+            newTsResolvedVersion,
+            isGo
         };
     }
     else {
@@ -1288,23 +1300,25 @@ async function downloadTsAsync(cwd: string, params: ScheduledParams | TriggeredP
     }
 }
 
-export async function downloadTsRepoAsync(cwd: string, repoUrl: string, headRef: string, target: TsEntrypoint, isGo: boolean): Promise<{ tsEntrypointPath: string, resolvedVersion: string }> {
+export async function downloadTsRepoAsync(cwd: string, repoUrl: string, headRef: string, target: TsEntrypoint, isGoHint: boolean): Promise<DownloadedTs> {
     console.log(`Cloning ${repoUrl} at ref ${headRef}`);
-    const repoName = isGo ? `typescript-go-${headRef}` : `typescript-${headRef}`;
+    const repoName = isGoHint ? `typescript-go-${headRef}` : `typescript-${headRef}`;
     await git.cloneRepoIfNecessary(cwd, { name: repoName, url: repoUrl, branch: headRef });
 
     const repoPath = path.join(cwd, repoName);
+    const { tsEntrypointPath, isGo } = await buildTs(repoPath, target);
 
     return {
-        tsEntrypointPath: await buildTs(repoPath, target),
-        resolvedVersion: headRef
+        tsEntrypointPath,
+        resolvedVersion: headRef,
+        isGo
     };
 }
 
-async function downloadTsPrAsync(cwd: string, repoUrl: string, prNumber: number, target: TsEntrypoint, isGo: boolean): Promise<{ tsEntrypointPath: string, resolvedVersion: string }> {
+async function downloadTsPrAsync(cwd: string, repoUrl: string, prNumber: number, target: TsEntrypoint, isGoHint: boolean): Promise<DownloadedTs> {
     console.log(`Cloning ${repoUrl} at pull ${prNumber}`);
 
-    const repoName = isGo ? `typescript-go-${prNumber}` : `typescript-${prNumber}`;
+    const repoName = isGoHint ? `typescript-go-${prNumber}` : `typescript-${prNumber}`;
     console.log(`Building in ${repoName}`);
 
     await git.cloneRepoIfNecessary(cwd, { name: repoName, url: repoUrl });
@@ -1313,20 +1327,39 @@ async function downloadTsPrAsync(cwd: string, repoUrl: string, prNumber: number,
     const headRef = `refs/pull/${prNumber}/merge`;
 
     await git.checkout(repoPath, headRef);
+    const { tsEntrypointPath, isGo } = await buildTs(repoPath, target);
 
     return {
-        tsEntrypointPath: await buildTs(repoPath, target),
-        resolvedVersion: headRef
+        tsEntrypointPath,
+        resolvedVersion: headRef,
+        isGo
     };
 }
 
-async function buildTs(repoPath: string, entrypoint: TsEntrypoint) {
+export function isTsgoPackage(packageJson: { name?: string }): boolean {
+    return packageJson.name !== "typescript";
+}
+
+async function buildTs(repoPath: string, entrypoint: TsEntrypoint): Promise<{ tsEntrypointPath: string, isGo: boolean }> {
+    const packageJsonPath = path.join(repoPath, "package.json");
+    const packageJson = JSON.parse(await fs.promises.readFile(packageJsonPath, { encoding: "utf-8" })) as { name?: string };
+    const isGo = isTsgoPackage(packageJson);
+
     await execAsync(repoPath, "npm ci");
     console.log(`Building in ${repoPath}`);
 
-    if (repoPath.includes("typescript-go")) {
+    if (isGo) {
         await execAsync(repoPath, `npx hereby build`);
-        return path.join(repoPath, "built", "local", "tsgo");
+        const candidates = [
+            path.join(repoPath, "built", "local", "tsc"),
+            path.join(repoPath, "built", "local", "tsgo"),
+        ];
+        for (const tsEntrypointPath of candidates) {
+            if (await pu.exists(tsEntrypointPath)) {
+                return { tsEntrypointPath, isGo };
+            }
+        }
+        throw new Error(`Cannot find tsgo entrypoint in ${path.join(repoPath, "built", "local")}`);
     }
     else {
         await execAsync(repoPath, `npx gulp ${entrypoint}`);
@@ -1337,11 +1370,11 @@ async function buildTs(repoPath: string, entrypoint: TsEntrypoint) {
             await execAsync(repoPath, "npx gulp LKG");
         }
 
-        return path.join(repoPath, "built", "local", `${entrypoint}.js`);
+        return { tsEntrypointPath: path.join(repoPath, "built", "local", `${entrypoint}.js`), isGo };
     }
 }
 
-async function downloadTsNpmAsync(cwd: string, version: string, entrypoint: TsEntrypoint): Promise<{ tsEntrypointPath: string, resolvedVersion: string }> {
+async function downloadTsNpmAsync(cwd: string, version: string, entrypoint: TsEntrypoint): Promise<DownloadedTs> {
     const tarName = (await execAsync(cwd, `npm pack typescript@${version} --quiet`)).trim();
 
     const tarMatch = /^(typescript-(.+))\..+$/.exec(tarName);
@@ -1361,10 +1394,10 @@ async function downloadTsNpmAsync(cwd: string, version: string, entrypoint: TsEn
         throw new Error("Cannot find file " + tsEntrypointPath);
     }
 
-    return { tsEntrypointPath, resolvedVersion };
+    return { tsEntrypointPath, resolvedVersion, isGo: false };
 }
 
-async function downloadTsNativePreviewNpmAsync(cwd: string, version: string): Promise<{ tsEntrypointPath: string, resolvedVersion: string }> {
+async function downloadTsNativePreviewNpmAsync(cwd: string, version: string): Promise<DownloadedTs> {
     const packageName = `native-preview-${process.platform}-${process.arch}`
     const tarName = (await execAsync(cwd, `npm pack @typescript/${packageName}@${version} --quiet`)).trim();
 
@@ -1385,5 +1418,5 @@ async function downloadTsNativePreviewNpmAsync(cwd: string, version: string): Pr
         throw new Error("Cannot find file " + tsEntrypointPath);
     }
 
-    return { tsEntrypointPath, resolvedVersion };
+    return { tsEntrypointPath, resolvedVersion, isGo: true };
 }

--- a/src/postGithubComments.ts
+++ b/src/postGithubComments.ts
@@ -12,10 +12,10 @@ if (argv.length !== 14) {
     process.exit(-1);
 }
 
-const [, , entrypoint, userToTag, prNumber, commentNumber, distinctId, isTop, resultDirPath, artifactsUri, post, repoCount, getArtifactsApi, isGoStr] = argv;
+const [, , entrypoint, userToTag, prNumber, commentNumber, distinctId, isTop, resultDirPath, artifactsUri, post, repoCount, getArtifactsApi, isTypeScriptGoRepoStr] = argv;
 const isTopReposRun = isTop.toLowerCase() === "true";
 const postResult = post.toLowerCase() === "true";
-const isGoRepo = isGoStr.toLowerCase() === "true";
+const isTypeScriptGoRepo = isTypeScriptGoRepoStr.toLowerCase() === "true";
 const metadataFilePaths = pu.glob(resultDirPath, `**/${metadataFileName}`);
 
 let newTscResolvedVersion: string | undefined;
@@ -82,7 +82,7 @@ let header = `@${userToTag} Here are the results of running the ${suiteDescripti
 ${summary.join("\n")}`;
 
 if (!outputs.length) {
-    git.createComment(isGoRepo, +prNumber, +commentNumber, distinctId, postResult, [header], somethingChanged);
+    git.createComment(isTypeScriptGoRepo, +prNumber, +commentNumber, distinctId, postResult, [header], somethingChanged);
 }
 else {
     const oldErrorHeader = `<h2>:warning: Old server errors :warning:</h2>`;
@@ -137,5 +137,5 @@ else {
         console.log(`Chunk of size ${chunk.length}`);
     }
 
-    git.createComment(isGoRepo, +prNumber, +commentNumber, distinctId, postResult, bodyChunks, somethingChanged);
+    git.createComment(isTypeScriptGoRepo, +prNumber, +commentNumber, distinctId, postResult, bodyChunks, somethingChanged);
 }

--- a/src/postGithubIssue.ts
+++ b/src/postGithubIssue.ts
@@ -11,10 +11,10 @@ if (argv.length !== 12) {
     process.exit(-1);
 }
 
-const [, , ep, language, repoCount, repoStartIndex, resultDirPath, logUri, artifactsUri, post, getArtifactsApi, isGoStr] = argv;
+const [, , ep, language, repoCount, repoStartIndex, resultDirPath, logUri, artifactsUri, post, getArtifactsApi, isTypeScriptGoRepoStr] = argv;
 const postResult = post.toLowerCase() === "true";
 const entrypoint = ep as TsEntrypoint;
-const isGoRepo = isGoStr.toLowerCase() === "true";
+const isTypeScriptGoRepo = isTypeScriptGoRepoStr.toLowerCase() === "true";
 
 const metadataFilePaths = pu.glob(resultDirPath, `**/${metadataFileName}`);
 
@@ -114,4 +114,4 @@ if (entrypoint !== "tsserver" && entrypoint !== "fuzzer") {
 
 
 const bodyChunks = [header, ...outputs];
-git.createIssue(isGoRepo, postResult, title, bodyChunks, /*sawNewErrors*/ !!outputs.length);
+git.createIssue(isTypeScriptGoRepo, postResult, title, bodyChunks, /*sawNewErrors*/ !!outputs.length);

--- a/src/utils/gitUtils.ts
+++ b/src/utils/gitUtils.ts
@@ -16,8 +16,8 @@ export interface Repo {
     branch?: string;
 }
 
-function getRepoProperties(isGoRepo: boolean) {
-    if (isGoRepo) {
+function getRepoProperties(isTypeScriptGoRepo: boolean) {
+    if (isTypeScriptGoRepo) {
         return {
             owner: "microsoft",
             repo: "typescript-go",
@@ -114,8 +114,8 @@ type Result = {
 export type GitResult = Result & { kind: 'git', title: string }
 export type UserResult = Result & { kind: 'user', issue_number: number }
 
-export async function createIssue(isGoRepo: boolean, postResult: boolean, title: string, bodyChunks: readonly string[], sawNewErrors: boolean): Promise<GitResult | undefined> {
-    const repoProperties = getRepoProperties(isGoRepo);
+export async function createIssue(isTypeScriptGoRepo: boolean, postResult: boolean, title: string, bodyChunks: readonly string[], sawNewErrors: boolean): Promise<GitResult | undefined> {
+    const repoProperties = getRepoProperties(isTypeScriptGoRepo);
     const issue = {
         ...repoProperties,
         title,
@@ -168,8 +168,8 @@ export async function createIssue(isGoRepo: boolean, postResult: boolean, title:
     }
 }
 
-export async function createComment(isGoRepo: boolean, prNumber: number, statusComment: number, distinctId: string, postResult: boolean, bodyChunks: readonly string[], somethingChanged: boolean): Promise<void> {
-    const repoProperties = getRepoProperties(isGoRepo);
+export async function createComment(isTypeScriptGoRepo: boolean, prNumber: number, statusComment: number, distinctId: string, postResult: boolean, bodyChunks: readonly string[], somethingChanged: boolean): Promise<void> {
+    const repoProperties = getRepoProperties(isTypeScriptGoRepo);
     const newComments = bodyChunks.map(body => ({
         ...repoProperties,
         issue_number: prNumber,

--- a/test/getTscErrors.test.ts
+++ b/test/getTscErrors.test.ts
@@ -10,7 +10,7 @@ describe("getErrors", () => {
             if (!existsSync("./testDownloads/getErrors")) {
                 mkdirSync("./testDownloads/getErrors", { recursive: true });
             }
-            await downloadTsRepoAsync('./testDownloads/getErrors', 'https://github.com/sandersn/typescript', 'test-fake-error', 'tsc', "strada");
+            await downloadTsRepoAsync('./testDownloads/getErrors', 'https://github.com/sandersn/typescript', 'test-fake-error', 'tsc');
         }
     });
 

--- a/test/getTscErrors.test.ts
+++ b/test/getTscErrors.test.ts
@@ -10,7 +10,7 @@ describe("getErrors", () => {
             if (!existsSync("./testDownloads/getErrors")) {
                 mkdirSync("./testDownloads/getErrors", { recursive: true });
             }
-            await downloadTsRepoAsync('./testDownloads/getErrors', 'https://github.com/sandersn/typescript', 'test-fake-error', 'tsc', false);
+            await downloadTsRepoAsync('./testDownloads/getErrors', 'https://github.com/sandersn/typescript', 'test-fake-error', 'tsc', "strada");
         }
     });
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,4 +1,4 @@
-import { getTscRepoResult, downloadTsRepoAsync, isTsgoPackage, mainAsync } from '../src/main'
+import { getTscRepoResult, detectTypeScriptImplementation, downloadTsRepoAsync, mainAsync } from '../src/main'
 import { execSync } from "child_process"
 import path = require("path")
 import { createCopyingOverlayFS } from '../src/utils/overlayFS'
@@ -83,9 +83,9 @@ describe("main", () => {
     jest.setTimeout(10 * 60 * 1000);
 
     it("detects tsgo from the root package name", () => {
-        expect(isTsgoPackage({ name: "typescript" })).toBe(false);
-        expect(isTsgoPackage({ name: "typescript-go" })).toBe(true);
-        expect(isTsgoPackage({ name: "@typescript/repo" })).toBe(true);
+        expect(detectTypeScriptImplementation({ name: "typescript" })).toBe("strada");
+        expect(detectTypeScriptImplementation({ name: "typescript-go" })).toBe("corsa");
+        expect(detectTypeScriptImplementation({ name: "@typescript/repo" })).toBe("corsa");
     });
 
     xit("build-only correctly caches", async () => {
@@ -112,8 +112,8 @@ describe("main", () => {
         actualFs.mkdirSync(repoPath, { recursive: true });
         actualFs.writeFileSync(path.join(repoPath, "package.json"), JSON.stringify({ name: "typescript" }));
         try {
-            const result = await downloadTsRepoAsync('./testDownloads/main', 'https://github.com/sandersn/typescript', 'test-fake-error', 'tsc', false)
-            expect(result.isGo).toBe(false);
+            const result = await downloadTsRepoAsync('./testDownloads/main', 'https://github.com/sandersn/typescript', 'test-fake-error', 'tsc', "strada")
+            expect(result.implementation).toBe("strada");
         }
         finally {
             actualFs.rmSync(repoPath, { recursive: true });
@@ -132,8 +132,8 @@ describe("main", () => {
         actualFs.writeFileSync(path.join(repoPath, "package.json"), JSON.stringify({ name: packageName }));
         actualFs.writeFileSync(executablePath, "");
         try {
-            const result = await downloadTsRepoAsync("./testDownloads/main", "https://github.com/microsoft/TypeScript", headRef, "tsc", false);
-            expect(result.isGo).toBe(true);
+            const result = await downloadTsRepoAsync("./testDownloads/main", "https://github.com/microsoft/TypeScript", headRef, "tsc", "strada");
+            expect(result.implementation).toBe("corsa");
             expect(result.tsEntrypointPath).toBe(executablePath);
         }
         finally {
@@ -165,7 +165,7 @@ describe("main", () => {
             newTsNpmVersion: 'next',
             resultDirName: 'RepoResults123',
             prngSeed: 'testSeed',
-            isGo: false,
+            implementationHint: "strada",
         });
 
         // Remove all references to the base path so that snapshot pass successfully.
@@ -210,7 +210,7 @@ describe("main", () => {
             newTsNpmVersion: 'next',
             resultDirName: 'RepoResults123',
             prngSeed: 'testSeed',
-            isGo: false
+            implementationHint: "strada"
         });
 
         // Remove all references to the base path so that snapshot pass successfully.

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -112,7 +112,7 @@ describe("main", () => {
         actualFs.mkdirSync(repoPath, { recursive: true });
         actualFs.writeFileSync(path.join(repoPath, "package.json"), JSON.stringify({ name: "typescript" }));
         try {
-            const result = await downloadTsRepoAsync('./testDownloads/main', 'https://github.com/sandersn/typescript', 'test-fake-error', 'tsc', "strada")
+            const result = await downloadTsRepoAsync('./testDownloads/main', 'https://github.com/sandersn/typescript', 'test-fake-error', 'tsc')
             expect(result.implementation).toBe("strada");
         }
         finally {
@@ -121,18 +121,18 @@ describe("main", () => {
     });
 
     it.each([
-        ["typescript-go", "tsgo"],
-        ["@typescript/repo", "tsc"],
-    ])("detects a %s tsgo checkout", async (packageName, executableName) => {
+        ["typescript-go", "tsgo", "https://github.com/microsoft/typescript-go", "typescript-go"],
+        ["@typescript/repo", "tsc", "https://github.com/microsoft/TypeScript", "typescript"],
+    ])("detects a %s tsgo checkout", async (packageName, executableName, repoUrl, repoName) => {
         const actualFs = jest.requireActual('fs');
         const headRef = packageName.replaceAll(/[^a-z]/g, "");
-        const repoPath = `./testDownloads/main/typescript-${headRef}`;
+        const repoPath = `./testDownloads/main/${repoName}-${headRef}`;
         const executablePath = path.join(repoPath, "built", "local", executableName);
         actualFs.mkdirSync(path.dirname(executablePath), { recursive: true });
         actualFs.writeFileSync(path.join(repoPath, "package.json"), JSON.stringify({ name: packageName }));
         actualFs.writeFileSync(executablePath, "");
         try {
-            const result = await downloadTsRepoAsync("./testDownloads/main", "https://github.com/microsoft/TypeScript", headRef, "tsc", "strada");
+            const result = await downloadTsRepoAsync("./testDownloads/main", repoUrl, headRef, "tsc");
             expect(result.implementation).toBe("corsa");
             expect(result.tsEntrypointPath).toBe(executablePath);
         }
@@ -165,7 +165,7 @@ describe("main", () => {
             newTsNpmVersion: 'next',
             resultDirName: 'RepoResults123',
             prngSeed: 'testSeed',
-            implementationHint: "strada",
+            candidateImplementation: "strada",
         });
 
         // Remove all references to the base path so that snapshot pass successfully.
@@ -210,7 +210,7 @@ describe("main", () => {
             newTsNpmVersion: 'next',
             resultDirName: 'RepoResults123',
             prngSeed: 'testSeed',
-            implementationHint: "strada"
+            candidateImplementation: "strada"
         });
 
         // Remove all references to the base path so that snapshot pass successfully.

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,4 +1,4 @@
-import { getTscRepoResult, downloadTsRepoAsync, mainAsync } from '../src/main'
+import { getTscRepoResult, downloadTsRepoAsync, isTsgoPackage, mainAsync } from '../src/main'
 import { execSync } from "child_process"
 import path = require("path")
 import { createCopyingOverlayFS } from '../src/utils/overlayFS'
@@ -14,7 +14,9 @@ jest.mock('random-seed', () => ({
     },
 }));
 jest.mock("../src/utils/packageUtils", () => ({
-    exists: jest.fn().mockResolvedValue(true),
+    exists: jest.fn((filePath: string) => filePath.includes("testDownloads")
+        ? jest.requireActual("fs").existsSync(filePath)
+        : Promise.resolve(true)),
     getMonorepoOrder: jest.fn().mockResolvedValue([
         "./dirA/package.json",
         "./dirB/dirC/package.json",
@@ -48,6 +50,7 @@ jest.mock('fs', () => ({
         writeFile: jest.fn(),
         copyFile: jest.fn(),
         rename: jest.fn().mockResolvedValue(undefined),
+        readFile: jest.fn((path: string, options: unknown) => jest.requireActual('fs').promises.readFile(path, options)),
     },
     readFileSync: (path: string) => {
         if (path.endsWith("replay.txt")) {
@@ -79,6 +82,12 @@ const errorStdout = JSON.stringify({
 describe("main", () => {
     jest.setTimeout(10 * 60 * 1000);
 
+    it("detects tsgo from the root package name", () => {
+        expect(isTsgoPackage({ name: "typescript" })).toBe(false);
+        expect(isTsgoPackage({ name: "typescript-go" })).toBe(true);
+        expect(isTsgoPackage({ name: "@typescript/repo" })).toBe(true);
+    });
+
     xit("build-only correctly caches", async () => {
         const { status, summary } = await getTscRepoResult(
             {
@@ -97,16 +106,39 @@ describe("main", () => {
         expect(summary!.includes("- \`error TS2496: The 'arguments' object cannot be referenced in an arrow function in ES3 and ES5. Consider using a standard function expression.\`")).toBeTruthy()
     });
 
-    it("downloads from a branch", async () => {
+    it("detects a legacy TypeScript checkout", async () => {
         const actualFs = jest.requireActual('fs');
+        const repoPath = "./testDownloads/main/typescript-test-fake-error";
+        actualFs.mkdirSync(repoPath, { recursive: true });
+        actualFs.writeFileSync(path.join(repoPath, "package.json"), JSON.stringify({ name: "typescript" }));
+        try {
+            const result = await downloadTsRepoAsync('./testDownloads/main', 'https://github.com/sandersn/typescript', 'test-fake-error', 'tsc', false)
+            expect(result.isGo).toBe(false);
+        }
+        finally {
+            actualFs.rmSync(repoPath, { recursive: true });
+        }
+    });
 
-        if (!actualFs.existsSync("./testDownloads/main")) {
-            actualFs.mkdirSync("./testDownloads/main", { recursive: true });
+    it.each([
+        ["typescript-go", "tsgo"],
+        ["@typescript/repo", "tsc"],
+    ])("detects a %s tsgo checkout", async (packageName, executableName) => {
+        const actualFs = jest.requireActual('fs');
+        const headRef = packageName.replaceAll(/[^a-z]/g, "");
+        const repoPath = `./testDownloads/main/typescript-${headRef}`;
+        const executablePath = path.join(repoPath, "built", "local", executableName);
+        actualFs.mkdirSync(path.dirname(executablePath), { recursive: true });
+        actualFs.writeFileSync(path.join(repoPath, "package.json"), JSON.stringify({ name: packageName }));
+        actualFs.writeFileSync(executablePath, "");
+        try {
+            const result = await downloadTsRepoAsync("./testDownloads/main", "https://github.com/microsoft/TypeScript", headRef, "tsc", false);
+            expect(result.isGo).toBe(true);
+            expect(result.tsEntrypointPath).toBe(executablePath);
         }
-        else if (actualFs.existsSync("./testDownloads/main/typescript-test-fake-error")) {
-            execSync("cd ./testDownloads/main/typescript-test-fake-error && git restore . && cd ..")
+        finally {
+            actualFs.rmSync(repoPath, { recursive: true });
         }
-        await downloadTsRepoAsync('./testDownloads/main', 'https://github.com/sandersn/typescript', 'test-fake-error', 'tsc', false)
     });
 
     it("outputs server errors", async () => {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,4 +1,4 @@
-import { getTscRepoResult, detectTypeScriptImplementation, downloadTsRepoAsync, mainAsync } from '../src/main'
+import { getTscRepoResult, detectTypeScriptImplementation, detectTypeScriptNpmImplementation, downloadTsRepoAsync, mainAsync } from '../src/main'
 import { execSync } from "child_process"
 import path = require("path")
 import { createCopyingOverlayFS } from '../src/utils/overlayFS'
@@ -50,7 +50,12 @@ jest.mock('fs', () => ({
         writeFile: jest.fn(),
         copyFile: jest.fn(),
         rename: jest.fn().mockResolvedValue(undefined),
-        readFile: jest.fn((path: string, options: unknown) => jest.requireActual('fs').promises.readFile(path, options)),
+        readFile: jest.fn((filePath: string, options: unknown) => {
+            if (/typescript-(?:0\.0\.0|1\.1\.1)[\\/]package\.json$/.test(filePath)) {
+                return Promise.resolve(JSON.stringify({ name: "typescript" }));
+            }
+            return jest.requireActual('fs').promises.readFile(filePath, options);
+        }),
     },
     readFileSync: (path: string) => {
         if (path.endsWith("replay.txt")) {
@@ -86,6 +91,15 @@ describe("main", () => {
         expect(detectTypeScriptImplementation({ name: "typescript" })).toBe("strada");
         expect(detectTypeScriptImplementation({ name: "typescript-go" })).toBe("corsa");
         expect(detectTypeScriptImplementation({ name: "@typescript/repo" })).toBe("corsa");
+    });
+
+    it("detects Corsa npm packages from their platform dependencies", () => {
+        expect(detectTypeScriptNpmImplementation({})).toBe("strada");
+        expect(detectTypeScriptNpmImplementation({
+            optionalDependencies: {
+                "@typescript/typescript-linux-x64": "7.1.0-dev.20260813.1",
+            },
+        })).toBe("corsa");
     });
 
     xit("build-only correctly caches", async () => {
@@ -165,7 +179,6 @@ describe("main", () => {
             newTsNpmVersion: 'next',
             resultDirName: 'RepoResults123',
             prngSeed: 'testSeed',
-            candidateImplementation: "strada",
         });
 
         // Remove all references to the base path so that snapshot pass successfully.
@@ -210,7 +223,6 @@ describe("main", () => {
             newTsNpmVersion: 'next',
             resultDirName: 'RepoResults123',
             prngSeed: 'testSeed',
-            candidateImplementation: "strada"
         });
 
         // Remove all references to the base path so that snapshot pass successfully.


### PR DESCRIPTION
Detect tsgo mode from the checked-out TypeScript ref root package name instead of relying on the repository URL.

- Build migrated @typescript/repo refs with Hereby and use built/local/tsc
- Preserve legacy typescript-go support via built/local/tsgo
- Install Go for triggered TypeScript runs and recognize migrated Go stack paths
- Reject unsupported tsserver comparisons across the migration boundary

Tests: npm test -- --runInBand